### PR TITLE
Do not overwrite data from restart

### DIFF
--- a/src/ebfm/core/LOOP_climate_forcing.py
+++ b/src/ebfm/core/LOOP_climate_forcing.py
@@ -6,8 +6,6 @@ import numpy as np
 
 from ebfm.coupling import Coupler
 
-from .LOOP_general_functions import is_first_time_step
-
 from ebfm.core import logging
 
 logger = logging.getLogger(__name__)
@@ -73,8 +71,6 @@ def main(C, grid, IN, t, time, OUT, cpl: Coupler) -> tuple[dict, dict]:
     # Time since last snowfall event
     snowfall_mask = (IN["snow"] / (time["dt"] * C["dayseconds"])) > C["Pthres"]
     OUT["timelastsnow"][snowfall_mask] = time["TCUR"]
-    if is_first_time_step(t):
-        OUT["timelastsnow"][:] = time["TCUR"]
 
     # Potential temperature and lapse rate
     IN["Theta"] = IN["T"] * (C["Pref"] / IN["Pres"]) ** (C["Rd"] / C["Cp"])


### PR DESCRIPTION
I removed a part of the code which to my understanding would always overwrite the data coming from the restart file.

I think this would also be a good possibility to introduce some first integration tests (in this case initializing with / without restart and checking the correct value of `"timelastsnow"`).

# Author's Todos

- [ ] I ran the [pre-commit hooks](https://github.com/EBFMorg/EBFM?tab=readme-ov-file#developer-notes) and fixed all issues
- [ ] I added an entry under *develop* in the [CHANGELOG.md](https://github.com/EBFMorg/EBFM/blob/main/CHANGELOG.md) (may be skipped for minor changes not obervable for the user)
