### PR TITLE
Let `setuptools_scm` ignore tags not starting with v*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ requires = ["setuptools", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+git_describe_command = "git describe --tags --dirty --match v*"
 version_scheme = "post-release"
 local_scheme = "node-and-date"
 


### PR DESCRIPTION
Ignore tags that do not start with `v*`. This would otherwise cause problems with tags `baseline-...` that do not follow the formatting for versions specified in [PEP440](https://peps.python.org/pep-0440/).

# Author's Todos

- [x] I ran the [pre-commit hooks](https://github.com/EBFMorg/EBFM?tab=readme-ov-file#developer-notes) and fixed all issues