### PR TITLE
Fix units for SMB being passed to Elmer/Ice and develop general functionality for unit conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # develop
 
+* Add functionality for (optional) unit conversion of data received from/sent to other components. https://github.com/EBFMorg/EBFM/pull/106
 * Introduce option `--component-name` to allow configuration of the name this component used to identify to the coupler. https://github.com/EBFMorg/EBFM/pull/101
 
 # v0.3.0

--- a/src/ebfm/core/INIT.py
+++ b/src/ebfm/core/INIT.py
@@ -184,7 +184,7 @@ def init_constants():
     # ---------------------------------------------------------------------
     C["yeardays"] = DAYS_PER_YEAR
     C["dayseconds"] = SECONDS_PER_DAY
-
+    C["yearseconds"] = DAYS_PER_YEAR * SECONDS_PER_DAY
     return C
 
 

--- a/src/ebfm/core/INIT.py
+++ b/src/ebfm/core/INIT.py
@@ -184,6 +184,7 @@ def init_constants():
     # ---------------------------------------------------------------------
     C["yeardays"] = DAYS_PER_YEAR
     C["dayseconds"] = SECONDS_PER_DAY
+
     return C
 
 

--- a/src/ebfm/core/INIT.py
+++ b/src/ebfm/core/INIT.py
@@ -184,7 +184,6 @@ def init_constants():
     # ---------------------------------------------------------------------
     C["yeardays"] = DAYS_PER_YEAR
     C["dayseconds"] = SECONDS_PER_DAY
-    C["yearseconds"] = DAYS_PER_YEAR * SECONDS_PER_DAY
     return C
 
 

--- a/src/ebfm/core/config.py
+++ b/src/ebfm/core/config.py
@@ -226,6 +226,13 @@ class TimeConfig:
         assert total_seconds % step_seconds == 0, "Time interval must be divisible by time step."
         return int(round(total_seconds / step_seconds))
 
+    def time_step_in_days(self) -> float:
+        """Get the time step size in days.
+
+        @returns Time step size in days
+        """
+        return self.time_step.total_seconds() / SECONDS_PER_DAY
+
     def to_dict(self) -> dict:
         """Convert time configuration to a dictionary.
 
@@ -234,7 +241,7 @@ class TimeConfig:
         return {
             "ts": self.start_time,
             "te": self.end_time,
-            "dt": self.time_step.total_seconds() / SECONDS_PER_DAY,  # Convert to days
+            "dt": self.time_step_in_days(),
             "tn": self.tn(),
             "dT_UTC": self.dT_UTC,
         }

--- a/src/ebfm/core/config.py
+++ b/src/ebfm/core/config.py
@@ -233,6 +233,16 @@ class TimeConfig:
         """
         return self.time_step.total_seconds() / SECONDS_PER_DAY
 
+    def time_step_iso8601(self) -> str:
+        """Get the time step size in ISO 8601 duration format (e.g., "P0DT3H0M0S" for a 3-hour time step).
+
+        @returns Time step size in ISO 8601 duration format
+        """
+        import pandas as pd
+
+        dt = pd.Timedelta(days=self.time_step_in_days())
+        return dt.isoformat()
+
     def to_dict(self) -> dict:
         """Convert time configuration to a dictionary.
 

--- a/src/ebfm/coupling/components/base.py
+++ b/src/ebfm/coupling/components/base.py
@@ -4,11 +4,23 @@
 
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
+from collections.abc import Mapping, Callable
 import numpy as np
 
 if TYPE_CHECKING:
     from ebfm.coupling.couplers.base import Coupler
     from ebfm.coupling.fields.base import FieldSet
+
+
+def identity(x: np.ndarray) -> np.ndarray:
+    """
+    Identity function for default transform.
+
+    @param[in] x input data
+
+    @returns the input data unchanged
+    """
+    return x
 
 
 class Component(ABC):
@@ -38,12 +50,15 @@ class Component(ABC):
         """
         return self._coupler.__class__.__name__ == coupler_class_type
 
-    def _put_if_coupled(self, field_name: str, data_to_exchange: dict[str, np.ndarray]):
+    def _put_if_coupled(
+        self, field_name: str, data_to_exchange: Mapping[str, np.ndarray], transform: Callable = identity
+    ):
         """
         Put a source field if it is coupled.
 
         @param[in] field_name field name
         @param[in] data_to_exchange dictionary containing data to send
+        @param[in] transform optional function to apply to the data before sending (e.g. for unit conversion)
         """
         from ebfm.coupling.fields.base import ExchangeType
 
@@ -51,9 +66,9 @@ class Component(ABC):
             assert (
                 field_name in data_to_exchange
             ), f"Field '{field_name}' is missing in data_to_exchange for component '{self.name}'."
-            self._coupler.put(self.name, field_name, data_to_exchange[field_name])
+            self._coupler.put(self.name, field_name, transform(data_to_exchange[field_name]))
 
-    def _get_if_coupled(self, field_name: str) -> np.ndarray | None:
+    def _get_if_coupled(self, field_name: str, transform: Callable = identity) -> np.ndarray | None:
         """
         Get a target field from the coupler if it is coupled.
 
@@ -66,15 +81,15 @@ class Component(ABC):
         if self._coupler.has_field(self.name, field_name, ExchangeType.TARGET):
             data, err = self._coupler.get(self.name, field_name)
             assert data is not None, f"Received data for field '{field_name}' is None. {err}"
-            return data
+            return transform(data)
         return None
 
     @abstractmethod
-    def exchange(self, data_to_exchange: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+    def exchange(self, data_to_exchange: Mapping[str, np.ndarray]) -> dict[str, np.ndarray]:
         """
         Exchange of EBFM with this component
 
-        @param[in] data_to_exchange dictionary of field names and their data to be sent
+        @param[in] data_to_exchange read-only Mapping of field names to data to be sent
 
         @returns dictionary of received field data
         """

--- a/src/ebfm/coupling/components/elmer_ice.py
+++ b/src/ebfm/coupling/components/elmer_ice.py
@@ -84,6 +84,11 @@ class ElmerIce(Component):
         @returns dictionary of received field data
         """
         received_data: dict[str, np.ndarray] = {}
+        if "smb" in data_to_exchange.keys():
+            data_to_exchange["smb"] = self._coupler.get_conversion_per_year_factor() * data_to_exchange["smb"]
+
+        if "runoff" in data_to_exchange.keys():
+            data_to_exchange["runoff"] = self._coupler.get_conversion_per_year_factor() * data_to_exchange["runoff"]
 
         # Put data to Elmer/Ice
         self._put_if_coupled("T_ice", data_to_exchange)

--- a/src/ebfm/coupling/components/elmer_ice.py
+++ b/src/ebfm/coupling/components/elmer_ice.py
@@ -10,7 +10,8 @@ if TYPE_CHECKING:
 
 from .base import Component
 
-from ebfm.coupling.fields import FieldSet, Field, ExchangeType, days_to_iso
+from ebfm.coupling.fields import FieldSet, Field, ExchangeType, Timestep
+from ebfm.core.config import TimeConfig
 
 
 class ElmerIce(Component):
@@ -23,11 +24,11 @@ class ElmerIce(Component):
     def __init__(self, coupler: "Coupler"):
         super().__init__(coupler)
 
-    def get_field_definitions(self, time: dict[str, float]) -> FieldSet:
+    def get_field_definitions(self, time: TimeConfig) -> FieldSet:
         """
         Get generic field definitions for EBFM coupling to Elmer/Ice.
         """
-        timestep = days_to_iso(time["dt"])
+        timestep = Timestep(value=time.time_step_iso8601())
 
         return FieldSet(
             {

--- a/src/ebfm/coupling/components/elmer_ice.py
+++ b/src/ebfm/coupling/components/elmer_ice.py
@@ -87,17 +87,14 @@ class ElmerIce(Component):
         """
         received_data: dict[str, np.ndarray] = {}
 
-        # Put data to Elmer/Ice
-        self._put_if_coupled("T_ice", data_to_exchange)
-
         # For fields representing rates (e.g. SMB, runoff), we need to convert them from per timestep to per year
         # before sending to Elmer/Ice, which expects annual values.
-
         def map_per_timestep_to_per_year(x_per_timestep: np.ndarray) -> np.ndarray:
             return self._coupler.get_conversion_per_year_factor() * x_per_timestep
 
+        # Put data to Elmer/Ice
+        self._put_if_coupled("T_ice", data_to_exchange)
         self._put_if_coupled("smb", data_to_exchange, transform=map_per_timestep_to_per_year)
-
         self._put_if_coupled("runoff", data_to_exchange, transform=map_per_timestep_to_per_year)
 
         # Get data from Elmer/Ice

--- a/src/ebfm/coupling/components/elmer_ice.py
+++ b/src/ebfm/coupling/components/elmer_ice.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from typing import TYPE_CHECKING
+from collections.abc import Mapping
 import numpy as np
 
 if TYPE_CHECKING:
@@ -76,25 +77,28 @@ class ElmerIce(Component):
             }
         )
 
-    def exchange(self, data_to_exchange: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+    def exchange(self, data_to_exchange: Mapping[str, np.ndarray]) -> dict[str, np.ndarray]:
         """
         Exchange data with Elmer/Ice.
 
-        @param[in] data_to_exchange dictionary of field names and their data to be sent
+        @param[in] data_to_exchange read-only Mapping of field names to data to be sent
 
         @returns dictionary of received field data
         """
         received_data: dict[str, np.ndarray] = {}
-        if "smb" in data_to_exchange.keys():
-            data_to_exchange["smb"] = self._coupler.get_conversion_per_year_factor() * data_to_exchange["smb"]
-
-        if "runoff" in data_to_exchange.keys():
-            data_to_exchange["runoff"] = self._coupler.get_conversion_per_year_factor() * data_to_exchange["runoff"]
 
         # Put data to Elmer/Ice
         self._put_if_coupled("T_ice", data_to_exchange)
-        self._put_if_coupled("smb", data_to_exchange)
-        self._put_if_coupled("runoff", data_to_exchange)
+
+        # For fields representing rates (e.g. SMB, runoff), we need to convert them from per timestep to per year
+        # before sending to Elmer/Ice, which expects annual values.
+
+        def map_per_timestep_to_per_year(x_per_timestep: np.ndarray) -> np.ndarray:
+            return self._coupler.get_conversion_per_year_factor() * x_per_timestep
+
+        self._put_if_coupled("smb", data_to_exchange, transform=map_per_timestep_to_per_year)
+
+        self._put_if_coupled("runoff", data_to_exchange, transform=map_per_timestep_to_per_year)
 
         # Get data from Elmer/Ice
         h = self._get_if_coupled("h")

--- a/src/ebfm/coupling/components/elmer_ice.py
+++ b/src/ebfm/coupling/components/elmer_ice.py
@@ -13,6 +13,7 @@ from .base import Component
 
 from ebfm.coupling.fields import FieldSet, Field, ExchangeType, Timestep
 from ebfm.core.config import TimeConfig
+from ebfm.core.constants import DAYS_PER_YEAR
 
 
 class ElmerIce(Component):
@@ -90,7 +91,9 @@ class ElmerIce(Component):
         # For fields representing rates (e.g. SMB, runoff), we need to convert them from per timestep to per year
         # before sending to Elmer/Ice, which expects annual values.
         def map_per_timestep_to_per_year(x_per_timestep: np.ndarray) -> np.ndarray:
-            return self._coupler.get_conversion_per_year_factor() * x_per_timestep
+            x_per_day = x_per_timestep / self._coupler.get_time_step_in_days()
+            x_per_year = x_per_day * DAYS_PER_YEAR
+            return x_per_year
 
         # Put data to Elmer/Ice
         self._put_if_coupled("T_ice", data_to_exchange)

--- a/src/ebfm/coupling/components/icon_atmo.py
+++ b/src/ebfm/coupling/components/icon_atmo.py
@@ -117,16 +117,21 @@ class IconAtmo(Component):
         """
         received_data: dict[str, np.ndarray] = {}
 
+        # We need to convert precipitation received from ICON from kg / m^2 / s
+        # to the unit expected by EBFM (???)
+        def map_pr_icon_to_ebfm(x: np.ndarray) -> np.ndarray:
+            seconds_per_year = DAYS_PER_YEAR * SECONDS_PER_DAY
+            return x * seconds_per_year * 1e-3
+
         # Put data to IconAtmo
         self._put_if_coupled("albedo", data_to_exchange)
 
         # Get data from IconAtmo
-        pr = self._get_if_coupled("pr")
+        pr = self._get_if_coupled("pr", transform=map_pr_icon_to_ebfm)
         if pr is not None:
-            # convert precipitation from kg m-2 s-1 to m w.e.
-            received_data["pr"] = pr * self._coupler.get_seconds_per_year() * 1e-3
+            received_data["pr"] = pr
 
-        # TO DO: check what units are needed for pr_snow in EBFM
+        # TODO: check what units are needed for pr_snow in EBFM
         pr_snow = self._get_if_coupled("pr_snow")
         if pr_snow is not None:
             received_data["pr_snow"] = pr_snow

--- a/src/ebfm/coupling/components/icon_atmo.py
+++ b/src/ebfm/coupling/components/icon_atmo.py
@@ -10,7 +10,8 @@ if TYPE_CHECKING:
 
 from .base import Component
 
-from ebfm.coupling.fields import FieldSet, Field, ExchangeType, days_to_iso
+from ebfm.coupling.fields import FieldSet, Field, ExchangeType, Timestep
+from ebfm.core.config import TimeConfig
 
 
 class IconAtmo(Component):
@@ -23,11 +24,11 @@ class IconAtmo(Component):
     def __init__(self, coupler: "Coupler"):
         super().__init__(coupler)
 
-    def get_field_definitions(self, time: dict[str, float]) -> FieldSet:
+    def get_field_definitions(self, time: TimeConfig) -> FieldSet:
         """
         Get generic field definitions for EBFM coupling to IconAtmo.
         """
-        timestep = days_to_iso(time["dt"])
+        timestep = Timestep(value=time.time_step_iso8601())
 
         return FieldSet(
             {

--- a/src/ebfm/coupling/components/icon_atmo.py
+++ b/src/ebfm/coupling/components/icon_atmo.py
@@ -5,7 +5,7 @@
 from typing import TYPE_CHECKING
 from collections.abc import Mapping
 import numpy as np
-from ebfm.core.constants import DAYS_PER_YEAR, SECONDS_PER_DAY
+from ebfm.core.constants import SECONDS_PER_DAY
 
 if TYPE_CHECKING:
     from ebfm.coupling.couplers.base import Coupler
@@ -118,16 +118,18 @@ class IconAtmo(Component):
         received_data: dict[str, np.ndarray] = {}
 
         # We need to convert precipitation received from ICON from kg / m^2 / s
-        # to the unit expected by EBFM (???)
-        def map_pr_icon_to_ebfm(x: np.ndarray) -> np.ndarray:
-            seconds_per_year = DAYS_PER_YEAR * SECONDS_PER_DAY
-            return x * seconds_per_year * 1e-3
+        # to m w.e. (per EBFM timestep)
+        def map_pr_to_ebfm(precipitation: np.ndarray) -> np.ndarray:
+            mwe_per_second = precipitation * 1e-3
+            mwe_per_day = mwe_per_second * SECONDS_PER_DAY
+            mwe_per_timestep = mwe_per_day * self._coupler.get_time_step_in_days()
+            return mwe_per_timestep
 
         # Put data to IconAtmo
         self._put_if_coupled("albedo", data_to_exchange)
 
         # Get data from IconAtmo
-        pr = self._get_if_coupled("pr", transform=map_pr_icon_to_ebfm)
+        pr = self._get_if_coupled("pr", transform=map_pr_to_ebfm)
         if pr is not None:
             received_data["pr"] = pr
 

--- a/src/ebfm/coupling/components/icon_atmo.py
+++ b/src/ebfm/coupling/components/icon_atmo.py
@@ -5,6 +5,7 @@
 from typing import TYPE_CHECKING
 from collections.abc import Mapping
 import numpy as np
+from ebfm.core.constants import DAYS_PER_YEAR, SECONDS_PER_DAY
 
 if TYPE_CHECKING:
     from ebfm.coupling.couplers.base import Coupler
@@ -122,8 +123,10 @@ class IconAtmo(Component):
         # Get data from IconAtmo
         pr = self._get_if_coupled("pr")
         if pr is not None:
-            received_data["pr"] = pr
+            # convert precipitation from kg m-2 s-1 to m w.e.
+            received_data["pr"] = pr * self._coupler.get_seconds_per_year() * 1e-3
 
+        # TO DO: check what units are needed for pr_snow in EBFM
         pr_snow = self._get_if_coupled("pr_snow")
         if pr_snow is not None:
             received_data["pr_snow"] = pr_snow

--- a/src/ebfm/coupling/components/icon_atmo.py
+++ b/src/ebfm/coupling/components/icon_atmo.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from typing import TYPE_CHECKING
+from collections.abc import Mapping
 import numpy as np
 
 if TYPE_CHECKING:
@@ -105,11 +106,11 @@ class IconAtmo(Component):
             }
         )
 
-    def exchange(self, data_to_exchange: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+    def exchange(self, data_to_exchange: Mapping[str, np.ndarray]) -> dict[str, np.ndarray]:
         """
         Exchange data with IconAtmo.
 
-        @param[in] data_to_exchange dictionary of field names and their data to be sent
+        @param[in] data_to_exchange read-only Mapping of field names to data to be sent
 
         @returns dictionary of received field data
         """

--- a/src/ebfm/coupling/couplers/base.py
+++ b/src/ebfm/coupling/couplers/base.py
@@ -7,7 +7,6 @@ import numpy as np
 from enum import Enum
 
 from ebfm.core.grid import GridDict
-from ebfm.core.constants import DAYS_PER_YEAR
 
 from ebfm.elmer.mesh import Mesh as Grid  # for now use an alias
 
@@ -132,21 +131,16 @@ class Coupler(ABC, Generic[CouplerExchangeType]):
         """
         raise NotImplementedError("_setup method must be implemented in subclasses.")
 
-    def get_conversion_per_year_factor(self) -> float:
+    def get_time_step_in_days(self) -> float:
         """
-        Returns the conversion factor to scale a per-timestep value to a per-year value.
-
-        Performs the calculation based on the current time step size stored in the instance.
+        Get the current time step size of the model in days.
 
         @note This method assumes that self._time has been set (i.e. self.setup() has been called).
 
-        @return The conversion factor (unitless).
+        @returns time step size in days
         """
-        assert self._time is not None, "self._time must be set before calling get_conversion_per_year_factor."
-
-        ebfm_time_step = self._time.time_step_in_days()
-
-        return DAYS_PER_YEAR / ebfm_time_step
+        assert self._time is not None, "self._time must be set before calling get_time_step."
+        return self._time.time_step_in_days()
 
     def _add_grid(self, grid_name: str, grid: Grid):
         """

--- a/src/ebfm/coupling/couplers/base.py
+++ b/src/ebfm/coupling/couplers/base.py
@@ -101,9 +101,36 @@ class Coupler(ABC, Generic[CouplerExchangeType]):
             raise KeyError(f"Coupling to component '{component_name}' is not enabled.")
         return self._coupled_components[component_name]
 
-    @abstractmethod
     def setup(self, grid: GridDict, time: dict[str, float]):
-        raise NotImplementedError("setup method must be implemented in subclasses.")
+        """
+        Setup the coupling interface.
+
+        Performs initialization operations after init and before entering the
+        time loop
+
+        @param[in] grid Grid used by EBFM where coupling happens
+        @param[in] time dictionary with time parameters, e.g. {'tn': 12, 'dt': 0.125}
+        """
+        self._time = time
+
+        field_definitions = FieldSet()
+
+        for component in self._coupled_components.values():
+            field_definitions |= component.get_field_definitions(self._time)
+
+        self._setup(grid, field_definitions)
+
+    @abstractmethod
+    def _setup(self, grid: GridDict, field_definitions: FieldSet):
+        """
+        Perform coupler-specific setup tasks such as:
+        - Adding the grid to the coupler interface
+        - Adding coupled fields to the coupler interface based on component definitions
+
+        @param[in] grid grid information dictionary
+        @param[in] field_definitions set of field definitions collected from all coupled components
+        """
+        raise NotImplementedError("_setup method must be implemented in subclasses.")
 
     def get_conversion_per_year_factor(self) -> float:
         """

--- a/src/ebfm/coupling/couplers/base.py
+++ b/src/ebfm/coupling/couplers/base.py
@@ -12,7 +12,7 @@ from ebfm.core.constants import DAYS_PER_YEAR
 from ebfm.elmer.mesh import Mesh as Grid  # for now use an alias
 
 # from ebfm.core.geometry import Grid  # TODO: consider introducing a new data structure native to EBFM?
-from ebfm.core.config import CouplingConfig
+from ebfm.core.config import CouplingConfig, TimeConfig
 
 import logging
 
@@ -75,7 +75,7 @@ class Coupler(ABC, Generic[CouplerExchangeType]):
             self._coupled_components[icon_comp.name] = icon_comp
 
         self.fields: FieldSet = FieldSet()
-        self._time: dict[str, float] | None = None
+        self._time: TimeConfig | None = None  # will be set in setup()
 
     def has_coupling_to(self, component_name: str) -> bool:
         """
@@ -101,7 +101,7 @@ class Coupler(ABC, Generic[CouplerExchangeType]):
             raise KeyError(f"Coupling to component '{component_name}' is not enabled.")
         return self._coupled_components[component_name]
 
-    def setup(self, grid: GridDict, time: dict[str, float]):
+    def setup(self, grid: GridDict, time: TimeConfig):
         """
         Setup the coupling interface.
 
@@ -109,14 +109,14 @@ class Coupler(ABC, Generic[CouplerExchangeType]):
         time loop
 
         @param[in] grid Grid used by EBFM where coupling happens
-        @param[in] time dictionary with time parameters, e.g. {'tn': 12, 'dt': 0.125}
+        @param[in] time TimeConfig with time parameters
         """
         self._time = time
 
         field_definitions = FieldSet()
 
         for component in self._coupled_components.values():
-            field_definitions |= component.get_field_definitions(self._time)
+            field_definitions |= component.get_field_definitions(self._time.to_dict())
 
         self._setup(grid, field_definitions)
 

--- a/src/ebfm/coupling/couplers/base.py
+++ b/src/ebfm/coupling/couplers/base.py
@@ -116,7 +116,7 @@ class Coupler(ABC, Generic[CouplerExchangeType]):
         field_definitions = FieldSet()
 
         for component in self._coupled_components.values():
-            field_definitions |= component.get_field_definitions(self._time.to_dict())
+            field_definitions |= component.get_field_definitions(self._time)
 
         self._setup(grid, field_definitions)
 

--- a/src/ebfm/coupling/couplers/base.py
+++ b/src/ebfm/coupling/couplers/base.py
@@ -7,7 +7,7 @@ import numpy as np
 from enum import Enum
 
 from ebfm.core.grid import GridDict
-from ebfm.core.constants import DAYS_PER_YEAR, SECONDS_PER_DAY
+from ebfm.core.constants import DAYS_PER_YEAR
 
 from ebfm.elmer.mesh import Mesh as Grid  # for now use an alias
 
@@ -147,16 +147,6 @@ class Coupler(ABC, Generic[CouplerExchangeType]):
         ebfm_time_step = self._time.time_step_in_days()
 
         return DAYS_PER_YEAR / ebfm_time_step
-
-    def get_seconds_per_year(self) -> float:
-        """
-        Returns the number of seconds in a year.
-
-        This is a constant value based on the definition of a year in days and the number of seconds in a day.
-
-        @return The number of seconds in a year.
-        """
-        return DAYS_PER_YEAR * SECONDS_PER_DAY
 
     def _add_grid(self, grid_name: str, grid: Grid):
         """

--- a/src/ebfm/coupling/couplers/base.py
+++ b/src/ebfm/coupling/couplers/base.py
@@ -7,6 +7,8 @@ import numpy as np
 from enum import Enum
 
 from ebfm.core.grid import GridDict
+from ebfm.core.constants import DAYS_PER_YEAR
+
 from ebfm.elmer.mesh import Mesh as Grid  # for now use an alias
 
 # from ebfm.core.geometry import Grid  # TODO: consider introducing a new data structure native to EBFM?
@@ -73,7 +75,7 @@ class Coupler(ABC, Generic[CouplerExchangeType]):
             self._coupled_components[icon_comp.name] = icon_comp
 
         self.fields: FieldSet = FieldSet()
-        self._time = None
+        self._time: dict[str, float] | None = None
 
     def has_coupling_to(self, component_name: str) -> bool:
         """
@@ -103,8 +105,22 @@ class Coupler(ABC, Generic[CouplerExchangeType]):
     def setup(self, grid: GridDict, time: dict[str, float]):
         raise NotImplementedError("setup method must be implemented in subclasses.")
 
-    def get_conversion_per_year_factor(self):
-        raise NotImplementedError("setup method must be implemented in subclasses.")
+    def get_conversion_per_year_factor(self) -> float:
+        """
+        Returns the conversion factor to scale a per-timestep value to a per-year value.
+
+        Performs the calculation based on the current time step size stored in the instance.
+
+        @note This method assumes that self.time has been set and contains the key 'dt'.
+
+        @return The conversion factor (unitless).
+        """
+        assert self._time is not None, "Time information must be set before calling get_conversion_per_year_factor."
+        assert "dt" in self._time, "Time information must include 'dt' key representing the time step size."
+
+        ebfm_time_step = self._time["dt"]  # time step size in days
+
+        return DAYS_PER_YEAR / ebfm_time_step
 
     def _add_grid(self, grid_name: str, grid: Grid):
         """

--- a/src/ebfm/coupling/couplers/base.py
+++ b/src/ebfm/coupling/couplers/base.py
@@ -7,7 +7,7 @@ import numpy as np
 from enum import Enum
 
 from ebfm.core.grid import GridDict
-from ebfm.core.constants import DAYS_PER_YEAR
+from ebfm.core.constants import DAYS_PER_YEAR, SECONDS_PER_DAY
 
 from ebfm.elmer.mesh import Mesh as Grid  # for now use an alias
 
@@ -147,6 +147,16 @@ class Coupler(ABC, Generic[CouplerExchangeType]):
         ebfm_time_step = self._time.time_step_in_days()
 
         return DAYS_PER_YEAR / ebfm_time_step
+
+    def get_seconds_per_year(self) -> float:
+        """
+        Returns the number of seconds in a year.
+
+        This is a constant value based on the definition of a year in days and the number of seconds in a day.
+
+        @return The number of seconds in a year.
+        """
+        return DAYS_PER_YEAR * SECONDS_PER_DAY
 
     def _add_grid(self, grid_name: str, grid: Grid):
         """

--- a/src/ebfm/coupling/couplers/base.py
+++ b/src/ebfm/coupling/couplers/base.py
@@ -73,6 +73,7 @@ class Coupler(ABC, Generic[CouplerExchangeType]):
             self._coupled_components[icon_comp.name] = icon_comp
 
         self.fields: FieldSet = FieldSet()
+        self._time = None
 
     def has_coupling_to(self, component_name: str) -> bool:
         """
@@ -100,6 +101,9 @@ class Coupler(ABC, Generic[CouplerExchangeType]):
 
     @abstractmethod
     def setup(self, grid: GridDict, time: dict[str, float]):
+        raise NotImplementedError("setup method must be implemented in subclasses.")
+
+    def get_conversion_per_year_factor(self):
         raise NotImplementedError("setup method must be implemented in subclasses.")
 
     def _add_grid(self, grid_name: str, grid: Grid):

--- a/src/ebfm/coupling/couplers/base.py
+++ b/src/ebfm/coupling/couplers/base.py
@@ -138,14 +138,13 @@ class Coupler(ABC, Generic[CouplerExchangeType]):
 
         Performs the calculation based on the current time step size stored in the instance.
 
-        @note This method assumes that self.time has been set and contains the key 'dt'.
+        @note This method assumes that self._time has been set (i.e. self.setup() has been called).
 
         @return The conversion factor (unitless).
         """
-        assert self._time is not None, "Time information must be set before calling get_conversion_per_year_factor."
-        assert "dt" in self._time, "Time information must include 'dt' key representing the time step size."
+        assert self._time is not None, "self._time must be set before calling get_conversion_per_year_factor."
 
-        ebfm_time_step = self._time["dt"]  # time step size in days
+        ebfm_time_step = self._time.time_step_in_days()
 
         return DAYS_PER_YEAR / ebfm_time_step
 

--- a/src/ebfm/coupling/couplers/dummyCoupler.py
+++ b/src/ebfm/coupling/couplers/dummyCoupler.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from . import Coupler
 from .base import GridDict, CouplingConfig, CouplerErrorCode
-from ebfm.coupling.fields import GenericExchangeType
+from ebfm.coupling.fields import GenericExchangeType, FieldSet
 
 import logging
 
@@ -26,14 +26,11 @@ class DummyCoupler(Coupler):
         self._coupled_components = dict()
         logger.debug(f"DummyCoupler created for component '{coupling_config.component_name}'.")
 
-    def setup(self, grid: GridDict, time: dict[str, float]):
-        """Setup the coupling interface (does nothing for DummyCoupler)
-
-        Performs initialization operations after init and before entering the
-        time loop
+    def _setup(self, grid: GridDict, field_definitions: FieldSet):
+        """DummyCoupler has no specific setup operations.
 
         @param[in] grid Grid used by EBFM where coupling happens
-        @param[in] time dictionary with time parameters, e.g. {'tn': 12, 'dt': 0.125}
+        @param[in] field_definitions set of field definitions collected from all coupled components
         """
         logger.debug("Setup coupling...")
         logger.debug("Do nothing for DummyCoupler.")

--- a/src/ebfm/coupling/couplers/fakeCoupler.py
+++ b/src/ebfm/coupling/couplers/fakeCoupler.py
@@ -168,6 +168,7 @@ class FakeCoupler(Coupler):
         @param[in] time dictionary with time parameters, e.g. {'tn': 12, 'dt': 0.125}
         """
         self._n_points = self._infer_n_points(grid)
+        self._time = time
 
         field_definitions = FieldSet()
 

--- a/src/ebfm/coupling/couplers/fakeCoupler.py
+++ b/src/ebfm/coupling/couplers/fakeCoupler.py
@@ -158,7 +158,7 @@ class FakeCoupler(Coupler):
             "n_points, x, lon, lat, mask (for MATLAB/full EBFM grids)."
         )
 
-    def setup(self, grid: GridDict, time: dict[str, float]):
+    def _setup(self, grid: GridDict, field_definitions: FieldSet):
         """
         Store grid size so fake arrays can be sized correctly in :meth:`get`.
 
@@ -168,12 +168,6 @@ class FakeCoupler(Coupler):
         @param[in] time dictionary with time parameters, e.g. {'tn': 12, 'dt': 0.125}
         """
         self._n_points = self._infer_n_points(grid)
-        self._time = time
-
-        field_definitions = FieldSet()
-
-        for component in self._coupled_components.values():
-            field_definitions |= component.get_field_definitions(time)
 
         self._add_couples(field_definitions)
 

--- a/src/ebfm/coupling/couplers/yacCoupler.py
+++ b/src/ebfm/coupling/couplers/yacCoupler.py
@@ -42,18 +42,15 @@ class YACCoupler(Coupler[yac.ExchangeType]):
         self.grid: yac.UnstructuredGrid = None
         self.cell_centers: yac.Points = None
 
-    def setup(self, grid: GridDict, time: dict[str, float]):
+    def _setup(self, grid: GridDict, field_definitions: FieldSet):
         """
-        Setup the coupling interface
-
-        Performs initialization operations after init and before entering the
-        time loop
+        Register grid and coupling definitions with YAC.
 
         @note This is a collective operation for all components involved in the coupling. It may take some time as it
               involves significant communication and computes remapping weights.
 
         @param[in] grid Grid used by EBFM where coupling happens
-        @param[in] time dictionary with time parameters, e.g. {'tn': 12, 'dt': 0.125}
+        @param[in] field_definitions set of field definitions collected from all coupled components
         """
 
         grid_object: Grid = grid["mesh"]
@@ -62,16 +59,9 @@ class YACCoupler(Coupler[yac.ExchangeType]):
 
         self._add_grid(grid_name, grid_object)
 
-        field_definitions = FieldSet()
-
-        for component in self._coupled_components.values():
-            field_definitions |= component.get_field_definitions(time)
-
         self._add_couples(field_definitions)
 
         self.interface.enddef()
-
-        self._time = time
 
         for field in self.fields.all():
             assert isinstance(field, YACField), f"Expected YACField, got {type(field)}"

--- a/src/ebfm/coupling/couplers/yacCoupler.py
+++ b/src/ebfm/coupling/couplers/yacCoupler.py
@@ -6,8 +6,10 @@ import yac
 import numpy as np
 
 from ebfm.core import logging
+from ebfm.core.constants import SECONDS_PER_DAY, DAYS_PER_YEAR
 
 from .base import Coupler, Grid, GridDict, CouplingConfig, CouplerErrorCode
+
 
 # from coupling import Field  # TODO: rather use generic Field from coupling
 from ebfm.coupling.fields import FieldSet, Field, GenericExchangeType
@@ -41,6 +43,18 @@ class YACCoupler(Coupler[yac.ExchangeType]):
         self.grid: yac.UnstructuredGrid = None
         self.cell_centers: yac.Points = None
 
+    def get_conversion_per_year_factor(self) -> float:
+        """
+        Returns the conversion factor to scale a per-timestep value to a per-year value.
+
+        Performs the calculation based on the current time step size stored in the instance.
+
+        @note This method assumes that self.time has been set and contains the key 'dt'.
+
+        @return The conversion factor (unitless).
+        """
+        return (DAYS_PER_YEAR * SECONDS_PER_DAY) / (self._time["dt"] * SECONDS_PER_DAY)
+
     def setup(self, grid: GridDict, time: dict[str, float]):
         """
         Setup the coupling interface
@@ -69,6 +83,8 @@ class YACCoupler(Coupler[yac.ExchangeType]):
         self._add_couples(field_definitions)
 
         self.interface.enddef()
+
+        self._time = time
 
         for field in self.fields.all():
             assert isinstance(field, YACField), f"Expected YACField, got {type(field)}"

--- a/src/ebfm/coupling/couplers/yacCoupler.py
+++ b/src/ebfm/coupling/couplers/yacCoupler.py
@@ -6,7 +6,6 @@ import yac
 import numpy as np
 
 from ebfm.core import logging
-from ebfm.core.constants import SECONDS_PER_DAY, DAYS_PER_YEAR
 
 from .base import Coupler, Grid, GridDict, CouplingConfig, CouplerErrorCode
 
@@ -42,18 +41,6 @@ class YACCoupler(Coupler[yac.ExchangeType]):
         # will be initialized in self._add_grid()
         self.grid: yac.UnstructuredGrid = None
         self.cell_centers: yac.Points = None
-
-    def get_conversion_per_year_factor(self) -> float:
-        """
-        Returns the conversion factor to scale a per-timestep value to a per-year value.
-
-        Performs the calculation based on the current time step size stored in the instance.
-
-        @note This method assumes that self.time has been set and contains the key 'dt'.
-
-        @return The conversion factor (unitless).
-        """
-        return (DAYS_PER_YEAR * SECONDS_PER_DAY) / (self._time["dt"] * SECONDS_PER_DAY)
 
     def setup(self, grid: GridDict, time: dict[str, float]):
         """

--- a/src/ebfm/coupling/fields/__init__.py
+++ b/src/ebfm/coupling/fields/__init__.py
@@ -4,7 +4,7 @@
 
 from ebfm.coupling.couplers.helpers import coupling_supported
 
-from .base import Field, FieldSet, ExchangeType, GenericExchangeType, Timestep, days_to_iso  # noqa: F401
+from .base import Field, FieldSet, ExchangeType, GenericExchangeType, Timestep  # noqa: F401
 
 if coupling_supported:
     from .yacField import YACField  # noqa: F401

--- a/src/ebfm/coupling/fields/base.py
+++ b/src/ebfm/coupling/fields/base.py
@@ -47,19 +47,6 @@ class Field:
     metadata: str | None = None  # optional metadata
 
 
-def days_to_iso(days: float) -> Timestep:
-    """
-    Convert a time step in days to ISO 8601 format.
-
-    @param[in] days time step in days
-    @returns Generic Timestep with ISO 8601 duration string
-    """
-    import pandas as pd
-
-    dt = pd.Timedelta(days=days)
-    return Timestep(value=dt.isoformat())
-
-
 class FieldSet:
     """
     Set of fields.

--- a/src/ebfm/main.py
+++ b/src/ebfm/main.py
@@ -335,9 +335,7 @@ def main():
             logger.debug("Done.")
             logger.debug("Received the following data from ICON:", data_from_icon)
 
-            # convert precipitation from kg m-2 s-1 to m w.e.
-            # TODO: unit conversion to EBFM local units should happen inside the coupler
-            IN["P"] = data_from_icon["pr"] * time_config.time_step.total_seconds() * 1e-3
+            IN["P"] = data_from_icon["pr"]
             IN["snow"] = data_from_icon["pr_snow"]
             IN["SWin"] = data_from_icon["rsds"]
             IN["LWin"] = data_from_icon["rlds"]

--- a/src/ebfm/main.py
+++ b/src/ebfm/main.py
@@ -378,7 +378,9 @@ def main():
             logger.debug("Started...")
 
             data_to_elmer = {
-                "smb": OUT["smb"],
+                "smb": OUT["smb"]
+                / time_config.time_step.total_seconds()
+                * C["yearseconds"],  # convert from m w.e. per time step to m w.e. per year
                 "T_ice": OUT["T_ice"],
                 "runoff": OUT["runoff"],
             }

--- a/src/ebfm/main.py
+++ b/src/ebfm/main.py
@@ -310,7 +310,7 @@ def main():
     coupler_cls = ebfm.coupling.select_coupler_class(coupling_config)
     coupler = coupler_cls(coupling_config=coupling_config)
 
-    coupler.setup(grid, time)
+    coupler.setup(grid, time_config)
 
     # Time-loop
     logger.info("Entering time loop...")

--- a/src/ebfm/main.py
+++ b/src/ebfm/main.py
@@ -378,9 +378,7 @@ def main():
             logger.debug("Started...")
 
             data_to_elmer = {
-                "smb": OUT["smb"]
-                / time_config.time_step.total_seconds()
-                * C["yearseconds"],  # convert from m w.e. per time step to m w.e. per year
+                "smb": OUT["smb"],
                 "T_ice": OUT["T_ice"],
                 "runoff": OUT["runoff"],
             }

--- a/src/ebfm/main.py
+++ b/src/ebfm/main.py
@@ -335,9 +335,9 @@ def main():
             logger.debug("Done.")
             logger.debug("Received the following data from ICON:", data_from_icon)
 
-            IN["P"] = (
-                data_from_icon["pr"] * time["dt"] * C["dayseconds"] * 1e-3
-            )  # convert units from kg m-2 s-1 to m w.e.
+            # convert precipitation from kg m-2 s-1 to m w.e.
+            # TODO: unit conversion to EBFM local units should happen inside the coupler
+            IN["P"] = data_from_icon["pr"] * time_config.time_step.total_seconds() * 1e-3
             IN["snow"] = data_from_icon["pr_snow"]
             IN["SWin"] = data_from_icon["rsds"]
             IN["LWin"] = data_from_icon["rlds"]


### PR DESCRIPTION
At the moment, we are passing the variable `out['SMB']` via YAC to Elmer. However, the units are in `meters per timestep`. This is not what we want as Elmer works with `meters per year`. This PR fixes this and should work for arbitrary time steps in EBFM. 

# Author's Todos

- [x] I ran the [pre-commit hooks](https://github.com/EBFMorg/EBFM?tab=readme-ov-file#developer-notes) and fixed all issues
- [x] I added an entry under *develop* in the [CHANGELOG.md](https://github.com/EBFMorg/EBFM/blob/main/CHANGELOG.md) (may be skipped for minor changes not observable for the user)
