### PR TITLE
Add logger info coupling components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # develop
 
+* Coupler `put`/`get` operations now log a warning if coupler returns non-zero error code to investigate unexpected behavior, instead of silently ignoring it. Warning is intentionally non-fatal, because error may be transient or coupler-specific.
 * Revise helper script `reader.py`. https://github.com/EBFMorg/EBFM/pull/119.
 * Add reduced-size BedMachine Greenland NetCDF example (`examples/BedMachineGreenland-v5_lo.nc`) and two utility scripts under `tools/`: `nc_reduce_size.py` to produce smaller NetCDF copies (field selection and grid subsampling), and `nc_2_vtk.py` to convert NetCDF fields to VTK for visualisation in ParaView. https://github.com/EBFMorg/EBFM/pull/123.
 * Bug fixes in double depth method in INIT.py and LOOP_SNOW.py

--- a/src/ebfm/coupling/components/base.py
+++ b/src/ebfm/coupling/components/base.py
@@ -7,6 +7,10 @@ from typing import TYPE_CHECKING
 from collections.abc import Mapping, Callable
 import numpy as np
 
+from ebfm.core import logging
+
+logger = logging.getLogger(__name__)
+
 if TYPE_CHECKING:
     from ebfm.coupling.couplers.base import Coupler
     from ebfm.coupling.fields.base import FieldSet
@@ -66,7 +70,10 @@ class Component(ABC):
             assert (
                 field_name in data_to_exchange
             ), f"Field '{field_name}' is missing in data_to_exchange for component '{self.name}'."
-            self._coupler.put(self.name, field_name, transform(data_to_exchange[field_name]))
+            logger.debug(f"Putting field {field_name=}")
+            err = self._coupler.put(self.name, field_name, transform(data_to_exchange[field_name]))
+            if err:
+                logger.warning(f"Error code {err=} after put of {field_name=}")
 
     def _get_if_coupled(self, field_name: str, transform: Callable = identity) -> np.ndarray | None:
         """
@@ -79,7 +86,10 @@ class Component(ABC):
         from ebfm.coupling.fields.base import ExchangeType
 
         if self._coupler.has_field(self.name, field_name, ExchangeType.TARGET):
+            logger.debug(f"Getting field {field_name=}")
             data, err = self._coupler.get(self.name, field_name)
+            if err:
+                logger.warning(f"Error code {err=} after get of {field_name=}")
             assert data is not None, f"Received data for field '{field_name}' is None. {err}"
             return transform(data)
         return None

--- a/src/ebfm/coupling/components/base.py
+++ b/src/ebfm/coupling/components/base.py
@@ -76,9 +76,11 @@ class Component(ABC):
                 field_name in data_to_exchange
             ), f"Field '{field_name}' is missing in data_to_exchange for component '{self.name}'."
             logger.debug(f"Putting data for field '{field_name}' to coupler: {data_to_exchange[field_name]}")
-	    err = self._coupler.put(self.name, field_name, transform(data_to_exchange[field_name]))
+            err = self._coupler.put(self.name, field_name, transform(data_to_exchange[field_name]))
             if err:
-                logger.warning(f"Error code {err=} after put of {field_name=}")
+                logger.warning(
+                    f"Put for {field_name=} returned error code ({err=}). Please report this to the developers."
+                )
 
     def _get_if_coupled(self, field_name: str, transform: Callable = identity) -> np.ndarray | None:
         """
@@ -94,8 +96,10 @@ class Component(ABC):
             data, err = self._coupler.get(self.name, field_name)
             logger.debug(f"Received data for field '{field_name}' from coupler: {data}")
             if err:
-                logger.warning(f"Error code {err=} after get of {field_name=}")
-	    assert data is not None, f"Received data for field '{field_name}' is None. {err}"
+                logger.warning(
+                    f"Get for {field_name=} returned error code ({err=}). Please report this to the developers."
+                )
+            assert data is not None, f"Received data for field '{field_name}' is None. {err}"
             return transform(data)
         return None
 

--- a/src/ebfm/coupling/components/elmer_ice.py
+++ b/src/ebfm/coupling/components/elmer_ice.py
@@ -45,6 +45,7 @@ class ElmerIce(Component):
                     name="smb",
                     coupled_component=self,
                     timestep=timestep,
+                    metadata="Surface mass balance",
                     exchange_type=ExchangeType.SOURCE,
                 ),
                 Field(

--- a/src/ebfm/coupling/fields/yacField.py
+++ b/src/ebfm/coupling/fields/yacField.py
@@ -204,18 +204,19 @@ class YACField:
         field_role = yac_interface.get_field_role(
             self.field_handle.component_name, self.field_handle.grid_name, self.field_handle.name
         )
-        assert field_role in (yac.ExchangeType.SOURCE, yac.ExchangeType.TARGET), (
-            f"Field '{self.name}' has invalid YAC exchange type '{field_role}'. Must be either SOURCE or TARGET."
-        )
+        assert field_role in (
+            yac.ExchangeType.SOURCE,
+            yac.ExchangeType.TARGET,
+        ), f"Field '{self.name}' has invalid YAC exchange type '{field_role}'. Must be either SOURCE or TARGET."
 
         src_comp, src_grid, src_field = yac_interface.get_field_source(
             self.field_handle.component_name, self.field_handle.grid_name, self.field_handle.name
         )
 
         src_field_role = yac_interface.get_field_role(src_comp, src_grid, src_field)
-        assert src_field_role is yac.ExchangeType.SOURCE, (
-            f"Field '{self.name}' has invalid YAC exchange type '{field_role}'. Must be SOURCE."
-        )
+        assert (
+            src_field_role is yac.ExchangeType.SOURCE
+        ), f"Field '{self.name}' has invalid YAC exchange type '{field_role}'. Must be SOURCE."
 
         src_field_timestep = yac_interface.get_field_timestep(src_comp, src_grid, src_field)
 


### PR DESCRIPTION
Add logger information to base class of coupling components. Add metadata to smb ("Surface mass balance").

# Author's Todos

- [x] I ran the [pre-commit hooks](https://github.com/EBFMorg/EBFM?tab=readme-ov-file#developer-notes) and fixed all issues
- [x] I added an entry under *develop* in the [CHANGELOG.md](https://github.com/EBFMorg/EBFM/blob/main/CHANGELOG.md) (may be skipped for minor changes not observable for the user)