### PR TITLE
Make DoF location for exchanged fields configurable

### DIFF
--- a/src/ebfm/coupling/couplers/yacCoupler.py
+++ b/src/ebfm/coupling/couplers/yacCoupler.py
@@ -268,8 +268,9 @@ class YACCoupler(Coupler[yac.ExchangeType]):
             ), f"Cannot add field '{field.name}' for uncoupled component '{field.coupled_component.name}'."
 
             # TODO: make this configurable in Field base class
-            # dof_location = self.cell_centers
-            dof_location = self.cell_corners
+            # dof_location = self.cell_corners  # breaking existing code
+            
+            dof_location = self.cell_centers  # original setting
 
             yac_field = YACField.from_field(field).construct_yac_field(
                 self.interface, self.component, collection_size, dof_location

--- a/src/ebfm/coupling/couplers/yacCoupler.py
+++ b/src/ebfm/coupling/couplers/yacCoupler.py
@@ -41,6 +41,7 @@ class YACCoupler(Coupler[yac.ExchangeType]):
         # will be initialized in self._add_grid()
         self.grid: yac.UnstructuredGrid = None
         self.cell_centers: yac.Points = None
+        self.cell_corners: yac.Points = None
 
     def _setup(self, grid: GridDict, field_definitions: FieldSet):
         """
@@ -231,9 +232,11 @@ class YACCoupler(Coupler[yac.ExchangeType]):
         # Set global vertex indices at corner locations
         self.grid.set_global_index(grid.vertex_ids, yac.Location.CORNER)
 
-        # Define DOF locations at cell centers (where data is exchanged)
-        # Uses spherical averaging from mesh._compute_cell_centers()
+        # For DOFs at cell centers uses spherical averaging from mesh._compute_cell_centers()
         self.cell_centers = self.grid.def_points(yac.Location.CELL, grid.lon_cells, grid.lat_cells)
+
+        # For DOFs at cell corners, use the same coordinates as for vertices
+        self.cell_corners = self.grid.def_points(yac.Location.CORNER, grid.lon_vertices, grid.lon_vertices)
 
     def _add_couples(self, field_definitions: FieldSet):
         """
@@ -264,9 +267,14 @@ class YACCoupler(Coupler[yac.ExchangeType]):
                 field.coupled_component.name
             ), f"Cannot add field '{field.name}' for uncoupled component '{field.coupled_component.name}'."
 
+            # TODO: make this configurable in Field base class
+            # dof_location = self.cell_centers
+            dof_location = self.cell_corners
+
             yac_field = YACField.from_field(field).construct_yac_field(
-                self.interface, self.component, collection_size, self.cell_centers
+                self.interface, self.component, collection_size, dof_location
             )
+
             self.fields.add(yac_field)
 
     def _construct_coupling_post_sync(self):

--- a/src/ebfm/coupling/fields/yacField.py
+++ b/src/ebfm/coupling/fields/yacField.py
@@ -109,7 +109,7 @@ class YACField:
         )
 
     def construct_yac_field(
-        self, yac_interface: yac.YAC, yac_component: yac.Component, collection_size: int, cell_centers: yac.Points
+        self, yac_interface: yac.YAC, yac_component: yac.Component, collection_size: int, dof_location: yac.Points
     ) -> "YACField":
         """
         Create a new Field instance with the provided YAC field.
@@ -117,7 +117,7 @@ class YACField:
         @param[in] yac_interface handle to YAC interface
         @param[in] yac_component handle to YAC component object
         @param[in] collection_size size of the collection for this field
-        @param[in] cell_centers yac.Points of the grid for this field
+        @param[in] dof_location yac.Points of DoFs for this field
 
         @returns New Field instance with the provided YAC field
         """
@@ -133,7 +133,7 @@ class YACField:
         yac_field = yac.Field.create(
             self.name,
             yac_component,
-            cell_centers,
+            dof_location,
             collection_size,
             self.timestep.value,
             self.timestep.format,
@@ -204,18 +204,19 @@ class YACField:
         field_role = yac_interface.get_field_role(
             self.field_handle.component_name, self.field_handle.grid_name, self.field_handle.name
         )
-        assert field_role in (yac.ExchangeType.SOURCE, yac.ExchangeType.TARGET), (
-            f"Field '{self.name}' has invalid YAC exchange type '{field_role}'. Must be either SOURCE or TARGET."
-        )
+        assert field_role in (
+            yac.ExchangeType.SOURCE,
+            yac.ExchangeType.TARGET,
+        ), f"Field '{self.name}' has invalid YAC exchange type '{field_role}'. Must be either SOURCE or TARGET."
 
         src_comp, src_grid, src_field = yac_interface.get_field_source(
             self.field_handle.component_name, self.field_handle.grid_name, self.field_handle.name
         )
 
         src_field_role = yac_interface.get_field_role(src_comp, src_grid, src_field)
-        assert src_field_role is yac.ExchangeType.SOURCE, (
-            f"Field '{self.name}' has invalid YAC exchange type '{field_role}'. Must be SOURCE."
-        )
+        assert (
+            src_field_role is yac.ExchangeType.SOURCE
+        ), f"Field '{self.name}' has invalid YAC exchange type '{field_role}'. Must be SOURCE."
 
         src_field_timestep = yac_interface.get_field_timestep(src_comp, src_grid, src_field)
 


### PR DESCRIPTION
I changed the DoF location from cell corners to centers in #83. The motivation here was that the exchanged fields are conservative fields which need to be defined per-cell.

I now have a different use case where I just want to receive a field from another component and then I want to plot this field. The easiest way to do so is to just receive data on vertices - cell data would require additional connectivity information.

Even though my use-case is only a prototype development I still think it would be useful to be able to configure whether a field should be received on vertices or corners.

The development of a generic interface that allows configuration on component level is still a todo. Alternatively, the coupler could also return data for a fixed pre-defined set of locations, i.e. YAC would compute data for all fields on corners and cell centers by default. This would be a simple approach. However, it would require the user to look inside the specific coupler - thus make the interface less generic.

# Author's Todos

- [ ] I ran the [pre-commit hooks](https://github.com/EBFMorg/EBFM?tab=readme-ov-file#developer-notes) and fixed all issues
- [ ] I added an entry under *develop* in the [CHANGELOG.md](https://github.com/EBFMorg/EBFM/blob/main/CHANGELOG.md) (may be skipped for minor changes not observable for the user)
