### PR TITLE
Revise component config

### DIFF
--- a/src/ebfm/core/LOOP_EBM.py
+++ b/src/ebfm/core/LOOP_EBM.py
@@ -16,6 +16,10 @@ from ebfm.core import LOOP_EBM_SWout, LOOP_EBM_insolation
 
 from ebfm.coupling import Coupler
 
+from ebfm.core import logging
+
+logger = logging.getLogger(__name__)
+
 
 def main(C, OUT, IN, time2, grid, cpl: Coupler) -> dict:
     """
@@ -32,6 +36,7 @@ def main(C, OUT, IN, time2, grid, cpl: Coupler) -> dict:
     Returns:
         dict: Updated OUT dictionary containing energy balance results.
     """
+    logger.debug("Starting LOOP_EBM...")
     ###########################################################
     # SOLVE THE SURFACE ENERGY BALANCE
     ###########################################################

--- a/src/ebfm/core/LOOP_SNOW.py
+++ b/src/ebfm/core/LOOP_SNOW.py
@@ -6,6 +6,10 @@ import numpy as np
 
 from .constants import SECONDS_PER_HOUR
 
+from ebfm.core import logging
+
+logger = logging.getLogger(__name__)
+
 
 def main(C, OUT, IN, dt, grid, phys):
     """
@@ -21,6 +25,8 @@ def main(C, OUT, IN, dt, grid, phys):
     Returns:
         dict: Updated OUT dictionary.
     """
+
+    logger.debug("Starting LOOP_SNOW...")
 
     def snowfall_and_deposition():
         """

--- a/src/ebfm/core/LOOP_climate_forcing.py
+++ b/src/ebfm/core/LOOP_climate_forcing.py
@@ -10,6 +10,10 @@ from datetime import datetime, timedelta
 
 from .LOOP_general_functions import is_first_time_step
 
+from ebfm.core import logging
+
+logger = logging.getLogger(__name__)
+
 
 def main(C, grid, IN, t, time, OUT, cpl: Coupler) -> tuple[dict, dict]:
     """
@@ -36,6 +40,7 @@ def main(C, grid, IN, t, time, OUT, cpl: Coupler) -> tuple[dict, dict]:
         OUT contains a copy of these fields (required in
         LOOP_write_to_file)
     """
+    logger.debug("Starting LOOP_climate_forcing...")
     ###########################################################
     # SPECIFY/READ METEO FORCING
     ###########################################################

--- a/src/ebfm/core/LOOP_mass_balance.py
+++ b/src/ebfm/core/LOOP_mass_balance.py
@@ -4,6 +4,10 @@
 
 import numpy as np
 
+from ebfm.core import logging
+
+logger = logging.getLogger(__name__)
+
 
 def main(OUT, IN, C):
     """
@@ -17,6 +21,8 @@ def main(OUT, IN, C):
     Returns:
     - Updated `OUT` dictionary.
     """
+
+    logger.debug("Starting LOOP_mass_balance...")
 
     # Climatic mass balance
     OUT["smb"] = (

--- a/src/ebfm/core/config.py
+++ b/src/ebfm/core/config.py
@@ -115,6 +115,13 @@ class CouplingConfig:
         """Whether to couple this component to Elmer/Ice."""
         return self._active_coupling_to(ComponentId.ELMER_ICE)
 
+    def active_coupled_components(self) -> list[ComponentId]:
+        """Get a list of actively coupled components based on the configuration.
+
+        @returns List of ComponentId for which coupling is enabled
+        """
+        return [c for c in ComponentId if self._active_coupling_to(c)]
+
 
 class GridConfig:
     """

--- a/src/ebfm/core/config.py
+++ b/src/ebfm/core/config.py
@@ -51,8 +51,13 @@ class CouplingConfig:
         """
 
         self.component_name = args.component_name
-        self.couple_to_icon_atmo = args.couple_to_icon_atmo
-        self.couple_to_elmer_ice = args.couple_to_elmer_ice
+
+        self._coupled_components = set()
+        if args.couple_to_icon_atmo:
+            self._coupled_components.add("icon_atmo")
+        if args.couple_to_elmer_ice:
+            self._coupled_components.add("elmer_ice")
+
         self.use_fake_coupling = args.fake_coupling
 
         # Set field validation level from args (command-line argument with default 'FATAL')
@@ -73,7 +78,17 @@ class CouplingConfig:
 
         @returns True if coupling to any component is enabled, False otherwise
         """
-        return self.couple_to_icon_atmo or self.couple_to_elmer_ice
+        return len(self._coupled_components) > 0
+
+    @property
+    def couple_to_icon_atmo(self):
+        """Whether to couple this component to ICON atmosphere."""
+        return "icon_atmo" in self._coupled_components
+
+    @property
+    def couple_to_elmer_ice(self):
+        """Whether to couple this component to Elmer/Ice."""
+        return "elmer_ice" in self._coupled_components
 
 
 class GridConfig:

--- a/src/ebfm/core/config.py
+++ b/src/ebfm/core/config.py
@@ -87,7 +87,7 @@ class CouplingConfig:
 
         @returns True if coupling to any component is enabled, False otherwise
         """
-        return len(self._coupled_components) > 0
+        return any(self._coupled_components.values())
 
     def _active_coupling_to(self, component_id: ComponentId) -> bool:
         """Check if coupling to a specific component is enabled.
@@ -103,7 +103,7 @@ class CouplingConfig:
             component_id in self._coupled_components
         ), f"Coupling configuration is missing {component_id} entry. Make sure to explicitly set True/False for the "
         "given key in the __init__ method of CouplingConfig."
-        return self._coupled_components.get(component_id)
+        return self._coupled_components[component_id]
 
     @property
     def couple_to_icon_atmo(self):

--- a/src/ebfm/core/config.py
+++ b/src/ebfm/core/config.py
@@ -82,13 +82,6 @@ class CouplingConfig:
                 "This is fine if configuration is provided by other components or through the API."
             )
 
-    def defines_coupling(self) -> bool:
-        """Check if any coupling is defined in this configuration.
-
-        @returns True if coupling to any component is enabled, False otherwise
-        """
-        return any(self._coupled_components.values())
-
     def _active_coupling_to(self, component_id: ComponentId) -> bool:
         """Check if coupling to a specific component is enabled.
 
@@ -121,6 +114,13 @@ class CouplingConfig:
         @returns List of ComponentId for which coupling is enabled
         """
         return [c for c in ComponentId if self._active_coupling_to(c)]
+
+    def defines_coupling(self) -> bool:
+        """Check if any coupling is defined in this configuration.
+
+        @returns True if coupling to any component is enabled, False otherwise
+        """
+        return len(self.active_coupled_components()) > 0
 
 
 class GridConfig:

--- a/src/ebfm/core/config.py
+++ b/src/ebfm/core/config.py
@@ -28,14 +28,24 @@ class FieldValidationLevel(Enum):
     SILENT = "SILENT"  # Only log at debug level on mismatch
 
 
+class ComponentId(Enum):
+    """
+    Enumeration of component identifiers for EBFM coupling.
+
+    Lists identifiers for available components without having to import the component classes directly which would lead
+    to a circular import.
+    """
+
+    ICON_ATMO = "icon_atmo"
+    ELMER_ICE = "elmer_ice"
+
+
 class CouplingConfig:
     """
     Coupling configuration.
     """
 
     component_name: str  # Name of this component
-    couple_to_icon_atmo: bool  # Whether to couple this component to ICON atmosphere
-    couple_to_elmer_ice: bool  # Whether to couple this component to Elmer/Ice
     coupler_config: Path | None  # Path to the coupler configuration file
     field_validation_level: FieldValidationLevel  # Level of validation for field exchange types
     use_fake_coupling: bool  # Whether to use FakeCoupler instead of production backend
@@ -52,11 +62,10 @@ class CouplingConfig:
 
         self.component_name = args.component_name
 
-        self._coupled_components = set()
-        if args.couple_to_icon_atmo:
-            self._coupled_components.add("icon_atmo")
-        if args.couple_to_elmer_ice:
-            self._coupled_components.add("elmer_ice")
+        self._coupled_components = {
+            ComponentId.ICON_ATMO: args.couple_to_icon_atmo,
+            ComponentId.ELMER_ICE: args.couple_to_elmer_ice,
+        }
 
         self.use_fake_coupling = args.fake_coupling
 
@@ -80,15 +89,31 @@ class CouplingConfig:
         """
         return len(self._coupled_components) > 0
 
+    def _active_coupling_to(self, component_id: ComponentId) -> bool:
+        """Check if coupling to a specific component is enabled.
+
+        @note Asserts that the component name exists in self._coupled_components. This prevents forgetting to register
+              a component during initialization.
+
+        @param[in] component_name name of the component to check coupling for
+
+        @returns True if coupling to the specified component is enabled, False if disabled
+        """
+        assert (
+            component_id in self._coupled_components
+        ), f"Coupling configuration is missing {component_id} entry. Make sure to explicitly set True/False for the "
+        "given key in the __init__ method of CouplingConfig."
+        return self._coupled_components.get(component_id)
+
     @property
     def couple_to_icon_atmo(self):
         """Whether to couple this component to ICON atmosphere."""
-        return "icon_atmo" in self._coupled_components
+        return self._active_coupling_to(ComponentId.ICON_ATMO)
 
     @property
     def couple_to_elmer_ice(self):
         """Whether to couple this component to Elmer/Ice."""
-        return "elmer_ice" in self._coupled_components
+        return self._active_coupling_to(ComponentId.ELMER_ICE)
 
 
 class GridConfig:

--- a/src/ebfm/coupling/components/__init__.py
+++ b/src/ebfm/coupling/components/__init__.py
@@ -2,6 +2,14 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
+from ...core.config import ComponentId
+
 from .base import Component  # noqa: F401
-from .icon_atmo import IconAtmo  # noqa: F401
-from .elmer_ice import ElmerIce  # noqa: F401
+from .icon_atmo import IconAtmo
+from .elmer_ice import ElmerIce
+
+# maps a given ID to the component implementation to be used
+id2class = {
+    ComponentId.ELMER_ICE: ElmerIce,
+    ComponentId.ICON_ATMO: IconAtmo,
+}

--- a/src/ebfm/coupling/components/base.py
+++ b/src/ebfm/coupling/components/base.py
@@ -29,10 +29,15 @@ class Component(ABC):
     Each component owns its fields as an instance attribute.
     """
 
-    name: str  # name of this component
+    def __init__(self, coupler: "Coupler", name: str):
+        """
+        Initialize the component.
 
-    def __init__(self, coupler: "Coupler"):
+        @param[in] coupler Coupler instance to use for coupling
+        @param[in] name unique name of the component
+        """
         self._coupler = coupler
+        self.name = name
         pass
 
     def _uses_coupler(self, coupler_class_type) -> bool:

--- a/src/ebfm/coupling/components/elmer_ice.py
+++ b/src/ebfm/coupling/components/elmer_ice.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 from .base import Component
 
 from ebfm.coupling.fields import FieldSet, Field, ExchangeType, Timestep
-from ebfm.core.config import TimeConfig
+from ebfm.core.config import ComponentId, TimeConfig
 from ebfm.core.constants import DAYS_PER_YEAR
 
 
@@ -21,10 +21,8 @@ class ElmerIce(Component):
     Component class for Elmer/Ice model coupling.
     """
 
-    name = "elmer_ice"
-
-    def __init__(self, coupler: "Coupler"):
-        super().__init__(coupler)
+    def __init__(self, coupler: "Coupler", name: str = ComponentId.ELMER_ICE.value):
+        super().__init__(coupler, name)
 
     def get_field_definitions(self, time: TimeConfig) -> FieldSet:
         """

--- a/src/ebfm/coupling/components/icon_atmo.py
+++ b/src/ebfm/coupling/components/icon_atmo.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 from .base import Component
 
 from ebfm.coupling.fields import FieldSet, Field, ExchangeType, Timestep
-from ebfm.core.config import TimeConfig
+from ebfm.core.config import ComponentId, TimeConfig
 
 
 class IconAtmo(Component):
@@ -21,10 +21,8 @@ class IconAtmo(Component):
     Component class for ICON atmosphere model coupling.
     """
 
-    name = "icon_atmo"
-
-    def __init__(self, coupler: "Coupler"):
-        super().__init__(coupler)
+    def __init__(self, coupler: "Coupler", name: str = ComponentId.ICON_ATMO.value):
+        super().__init__(coupler, name)
 
     def get_field_definitions(self, time: TimeConfig) -> FieldSet:
         """

--- a/src/ebfm/coupling/couplers/base.py
+++ b/src/ebfm/coupling/couplers/base.py
@@ -11,13 +11,13 @@ from ebfm.core.grid import GridDict
 from ebfm.elmer.mesh import Mesh as Grid  # for now use an alias
 
 # from ebfm.core.geometry import Grid  # TODO: consider introducing a new data structure native to EBFM?
-from ebfm.core.config import CouplingConfig, TimeConfig, ComponentId
+from ebfm.core.config import CouplingConfig, TimeConfig
 
 import logging
 
 from abc import ABC, abstractmethod
 
-from ebfm.coupling.components import Component, ElmerIce, IconAtmo
+from ebfm.coupling.components import Component, id2class
 from ebfm.coupling.fields import FieldSet, GenericExchangeType
 
 logger = logging.getLogger(__name__)
@@ -65,15 +65,11 @@ class Coupler(ABC, Generic[CouplerExchangeType]):
         """
         self._coupled_components: dict[str, Component] = {}
 
-        if coupling_config.couple_to_elmer_ice:
-            logger.debug("Coupling to Elmer/Ice enabled.")
-            elmer_comp = ElmerIce(coupler=self, name=ComponentId.ELMER_ICE.value)
-            self._coupled_components[ComponentId.ELMER_ICE.value] = elmer_comp
-
-        if coupling_config.couple_to_icon_atmo:
-            logger.debug("Coupling to ICON atmosphere enabled.")
-            icon_comp = IconAtmo(coupler=self, name=ComponentId.ICON_ATMO.value)
-            self._coupled_components[ComponentId.ICON_ATMO.value] = icon_comp
+        for id in coupling_config.active_coupled_components():
+            logger.debug(f"Coupling to {id.value} enabled.")
+            comp_class = id2class[id]
+            comp = comp_class(coupler=self, name=id.value)
+            self._coupled_components[id.value] = comp
 
         logger.debug(f"Active coupled components: {list(self._coupled_components.keys())}")
 

--- a/src/ebfm/coupling/couplers/base.py
+++ b/src/ebfm/coupling/couplers/base.py
@@ -66,12 +66,16 @@ class Coupler(ABC, Generic[CouplerExchangeType]):
         self._coupled_components: dict[str, Component] = {}
 
         if coupling_config.couple_to_elmer_ice:
+            logger.debug("Coupling to Elmer/Ice enabled.")
             elmer_comp = ElmerIce(self)
             self._coupled_components[elmer_comp.name] = elmer_comp
 
         if coupling_config.couple_to_icon_atmo:
+            logger.debug("Coupling to ICON atmosphere enabled.")
             icon_comp = IconAtmo(self)
             self._coupled_components[icon_comp.name] = icon_comp
+
+        logger.debug(f"Active coupled components: {list(self._coupled_components.keys())}")
 
         self.fields: FieldSet = FieldSet()
         self._time: TimeConfig | None = None  # will be set in setup()
@@ -84,7 +88,10 @@ class Coupler(ABC, Generic[CouplerExchangeType]):
 
         @returns True if coupling to the specified component is enabled, False otherwise
         """
-        return component_name in self._coupled_components
+        logger.debug(f"Checking coupling to component '{component_name}'...")
+        has_coupling_to_comp = component_name in self._coupled_components
+        logger.debug(f"has_coupling_to({component_name}) = {has_coupling_to_comp}")
+        return has_coupling_to_comp
 
     def get_component(self, component_name: str) -> Component:
         """

--- a/src/ebfm/coupling/couplers/base.py
+++ b/src/ebfm/coupling/couplers/base.py
@@ -11,7 +11,7 @@ from ebfm.core.grid import GridDict
 from ebfm.elmer.mesh import Mesh as Grid  # for now use an alias
 
 # from ebfm.core.geometry import Grid  # TODO: consider introducing a new data structure native to EBFM?
-from ebfm.core.config import CouplingConfig, TimeConfig
+from ebfm.core.config import CouplingConfig, TimeConfig, ComponentId
 
 import logging
 
@@ -67,13 +67,13 @@ class Coupler(ABC, Generic[CouplerExchangeType]):
 
         if coupling_config.couple_to_elmer_ice:
             logger.debug("Coupling to Elmer/Ice enabled.")
-            elmer_comp = ElmerIce(self)
-            self._coupled_components[elmer_comp.name] = elmer_comp
+            elmer_comp = ElmerIce(coupler=self, name=ComponentId.ELMER_ICE.value)
+            self._coupled_components[ComponentId.ELMER_ICE.value] = elmer_comp
 
         if coupling_config.couple_to_icon_atmo:
             logger.debug("Coupling to ICON atmosphere enabled.")
-            icon_comp = IconAtmo(self)
-            self._coupled_components[icon_comp.name] = icon_comp
+            icon_comp = IconAtmo(coupler=self, name=ComponentId.ICON_ATMO.value)
+            self._coupled_components[ComponentId.ICON_ATMO.value] = icon_comp
 
         logger.debug(f"Active coupled components: {list(self._coupled_components.keys())}")
 

--- a/src/ebfm/main.py
+++ b/src/ebfm/main.py
@@ -333,7 +333,7 @@ def main():
             data_from_icon = icon_atmo.exchange(data_to_icon)
 
             logger.debug("Done.")
-            logger.debug("Received the following data from ICON:", data_from_icon)
+            logger.debug(f"Received the following data from ICON: {data_from_icon}")
 
             IN["P"] = data_from_icon["pr"]
             IN["snow"] = data_from_icon["pr_snow"]
@@ -382,7 +382,7 @@ def main():
             }
             data_from_elmer = elmer_ice.exchange(data_to_elmer)
             logger.debug("Done.")
-            logger.debug("Received the following data from Elmer/Ice:", data_from_elmer)
+            logger.debug(f"Received the following data from Elmer/Ice: {data_from_elmer}")
 
             IN["h"] = data_from_elmer["h"]
             OUT["h"] = IN["h"]


### PR DESCRIPTION
While adding a new component I realized that during parsing/configuration there are some places where one can easily forget adding the required functions. I revised the registration of new components in the configuration.

Instead of individual members we now have a dictionary containing `True/False`. If a component is not registered in the dictionary the respective getter should fail (instead of always returning `False`).

Since I wanted to avoid duplication of labels for identifying components I had to move `Component.name` to a different place. Otherwise this would have lead to a circular include. I'm not 100% happy about the fact that a `Component` does not identify it's own name anymore. Instead, the name is defined from the outside. However, this also opens up a new use-case that we could have two different instances of, for example, an `ElmerIce` component which live under different names.

# Author's Todos

- [x] I ran the [pre-commit hooks](https://github.com/EBFMorg/EBFM?tab=readme-ov-file#developer-notes) and fixed all issues
- [x] I added an entry under *develop* in the [CHANGELOG.md](https://github.com/EBFMorg/EBFM/blob/main/CHANGELOG.md) (may be skipped for minor changes not observable for the user)
