### PR TITLE
Fix: CouplingConfig.comms initialisation causes RuntimeError on startup

### DIFF
--- a/src/ebfm/core/comm/mpi_handshake.py
+++ b/src/ebfm/core/comm/mpi_handshake.py
@@ -8,7 +8,6 @@ from mpi4py import MPI
 import numpy as np
 import sys
 
-
 __version__ = "1.0.0"
 
 

--- a/src/ebfm/core/config.py
+++ b/src/ebfm/core/config.py
@@ -50,7 +50,7 @@ class CouplingConfig:
     coupler_config: Path | None  # Path to the coupler configuration file
     field_validation_level: FieldValidationLevel  # Level of validation for field exchange types
     use_fake_coupling: bool  # Whether to use FakeCoupler instead of production backend
-    comms: dict[str, MPI.Comm]  # Dict with MPI communicators used by this model
+    comms: dict[str, MPI.Comm] | None  # Dict with MPI communicators used by this model
 
     def __init__(
         self,
@@ -72,7 +72,7 @@ class CouplingConfig:
         self.use_fake_coupling = args.fake_coupling
 
         # will be defined later because we already need some members of CouplingConfig to create the communicators
-        self.comms = {}
+        self.comms = None
 
         # Set field validation level from args (command-line argument with default 'FATAL')
         self.field_validation_level = FieldValidationLevel(args.field_validation_level)
@@ -113,7 +113,7 @@ class CouplingConfig:
         @param[in] group_label label of the group
         @returns True if a communicator for the group label is available, False otherwise
         """
-        return self.has_group_communicators() and group_label in self.comms
+        return self.has_group_communicators() and group_label in self.comms  # type: ignore[operator]
 
     def get_group_communicator(self, group_label: str) -> MPI.Comm:
         """Get the communicator for the given group label.
@@ -123,7 +123,7 @@ class CouplingConfig:
         """
         if not self.has_group_communicator(group_label):
             raise KeyError(f"Communicator for group label '{group_label}' not found.")
-        return self.comms[group_label]
+        return self.comms[group_label]  # type: ignore[index]
 
     def _active_coupling_to(self, component_id: ComponentId) -> bool:
         """Check if coupling to a specific component is enabled.


### PR DESCRIPTION
Problem: `self.comms = {}` led to a runtime error raising `RuntimeError: Group communicators have already been set.` 

This error is not shown as a failed test, see for example [here](https://github.com/EBFMorg/EBFM/actions/runs/26813778392/job/79050238306). Issue #118 was created to address this issue.

Fix: 
- `self.comms = None` + update the annotation to `dict[str, MPI.Comm] | None`
- Add `# type: ignore` on the two lines where `mypy` cannot narrow through method-call guards. This can be discussed and changed if a different solution is preferred. 

# Author's Todos

- [x] I ran the [pre-commit hooks](https://github.com/EBFMorg/EBFM?tab=readme-ov-file#developer-notes) and fixed all issues
- [x] I added an entry under *develop* in the [CHANGELOG.md](https://github.com/EBFMorg/EBFM/blob/main/CHANGELOG.md) (may be skipped for minor changes not observable for the user)
