### PR TITLE
Add Elmer mesh in this repository

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,4 @@
 
 # Files tracked with git LFS
 examples/BedMachineGreenland-v5_lo.nc filter=lfs diff=lfs merge=lfs -text
+examples/greenland_mesh_v0/** filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -7,4 +7,7 @@
 
 # Files tracked with git LFS
 examples/BedMachineGreenland-v5_lo.nc filter=lfs diff=lfs merge=lfs -text
-examples/greenland_mesh_v0/** filter=lfs diff=lfs merge=lfs -text
+examples/greenland_mesh_v0/MESH/mesh.nodes filter=lfs diff=lfs merge=lfs -text
+examples/greenland_mesh_v0/MESH/mesh.header filter=lfs diff=lfs merge=lfs -text
+examples/greenland_mesh_v0/MESH/mesh.elements filter=lfs diff=lfs merge=lfs -text
+examples/greenland_mesh_v0/MESH/mesh.boundary filter=lfs diff=lfs merge=lfs -text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # develop
 
+* Add Elmer Greenland Mesh in this repository for more conveniently running examples. https://github.com/EBFMorg/EBFM/pull/120.
 * Revise helper script `reader.py`. https://github.com/EBFMorg/EBFM/pull/119.
 * Add reduced-size BedMachine Greenland NetCDF example (`examples/BedMachineGreenland-v5_lo.nc`) and two utility scripts under `tools/`: `nc_reduce_size.py` to produce smaller NetCDF copies (field selection and grid subsampling), and `nc_2_vtk.py` to convert NetCDF fields to VTK for visualisation in ParaView. https://github.com/EBFMorg/EBFM/pull/123.
 * Bug fixes in double depth method in INIT.py and LOOP_SNOW.py

--- a/README.md
+++ b/README.md
@@ -105,8 +105,12 @@ Important: For some larger files we are using Git LFS. Please make sure to [inst
   Usage example:
 
   ```sh
-  ebfm --elmer-mesh examples/greenland_mesh_v0/MESH --elmer-mesh-crs-epsg 3413
+  ebfm --elmer-mesh examples/greenland_mesh_v0_with_DEM/MESH --elmer-mesh-crs-epsg 3413
   ```
+
+  Note: You can also use `--elmer-mesh examples/greenland_mesh_v0/MESH` here, but this will lead to a very unphysical
+  setup with zero elevation in the whole domain. To generate `examples/greenland_mesh_v0_with_DEM/MESH` please refer
+  to the section **Amend elevation data to 2D Elmer mesh** below.
 
 * Elmer Mesh with Elevation data from NetCDF: The Elmer mesh file provides x-y
   coordinate. An additioal NetCDF file is given to provide elevation data for

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ EBFM supports the following formats:
 For Elmer-based inputs, the argument `--elmer-mesh-crs-epsg` is needed to define the coordinate reference system (CRS)
 of the input x/y coordinates. EBFM uses this CRS to convert coordinates to lon/lat (EPSG:4326) internally.
 
+Important: For some larger files we are using Git LFS. Please make sure to [install Git LFS](https://git-lfs.com/).
+
 * MATLAB Mesh: An example is given in `examples/dem_and_mask.mat`. This mesh
   file provides x-y coordinates and elevation data. Please use the argument
   `--matlab-mesh /path/to/your/mesh.mat`.
@@ -98,26 +100,23 @@ of the input x/y coordinates. EBFM uses this CRS to convert coordinates to lon/l
 
 * Elmer Mesh: An Elmer mesh file with x-y coordinates of mesh points and
   elevation data stored in the z-component. Please use the argument
-  `--elmer-mesh /path/to/your/elmer/MESH`.
+  `--elmer-mesh /path/to/your/elmer/mesh`.
 
   Usage example:
 
   ```sh
-  ebfm --elmer-mesh examples/DEM --elmer-mesh-crs-epsg 3413
+  ebfm --elmer-mesh examples/greenland_mesh_v0/MESH --elmer-mesh-crs-epsg 3413
   ```
-
-  As an example, you can use the mesh from the Elmer/Ice website for the
-  [Greenland Ice Sheet](https://elmerice.elmerfem.org/wiki/doku.php?id=eis:greenland).
 
 * Elmer Mesh with Elevation data from NetCDF: The Elmer mesh file provides x-y
   coordinate. An additioal NetCDF file is given to provide elevation data for
-  these x-y coordinates. Please use the arguments `--elmer-mesh /path/to/your/elmer/MESH`
+  these x-y coordinates. Please use the arguments `--elmer-mesh /path/to/your/elmer/mesh`
   and `--netcdf-mesh /path/to/your/elevation.nc`
 
   Usage example:
 
   ```sh
-  ebfm --elmer-mesh examples/MESH --netcdf-mesh examples/BedMachineGreenland-v5_lo.nc --elmer-mesh-crs-epsg 3413
+  ebfm --elmer-mesh examples/greenland_mesh_v0/MESH --netcdf-mesh examples/BedMachineGreenland-v5_lo.nc --elmer-mesh-crs-epsg 3413
   ```
 
 Note that an Elmer mesh must be provided in a directory following the structure:
@@ -134,28 +133,31 @@ The option `--is-partitioned-elmer-mesh` will tell EBFM that the provided Elmer
 mesh is a partitioned mesh. A partitioned mesh file follows the structure:
 
 ```
-path/to/your/elmer/MESH
-    ├── mesh.boundary
-    ├── mesh.elements
-    ├── mesh.header
-    ├── mesh.nodes
-    └── partitioning.128
-        ├── part.1.boundary
-        ├── part.1.elements
-        ├── part.1.header
-        ├── part.1.nodes
-        ...
-        ├── part.128.boundary
-        ├── part.128.elements
-        ├── part.128.header
-        └── part.128.nodes
+path/to/your/elmer/mesh
+    └── MESH
+        ├── mesh.boundary
+        ├── mesh.elements
+        ├── mesh.header
+        ├── mesh.nodes
+        └── partitioning.128
+            ├── part.1.boundary
+            ├── part.1.elements
+            ├── part.1.header
+            ├── part.1.nodes
+            ...
+            ├── part.128.boundary
+            ├── part.128.elements
+            ├── part.128.header
+            └── part.128.nodes
 ```
 
 Usage example for partitioned mesh:
 
 ```sh
-ebfm --elmer-mesh examples/MESH/partitioning.128/ --netcdf-mesh examples/BedMachineGreenland-v5_lo.nc --is-partitioned-elmer-mesh --use-part 42
+ebfm --elmer-mesh examples/greenland_mesh_v0/MESH/partitioning.128/ --netcdf-mesh examples/BedMachineGreenland-v5_lo.nc --is-partitioned-elmer-mesh --use-part 42
 ```
+
+Note: The partitioned mesh is not included in this repository.
 
 ### Getting the example data
 
@@ -174,28 +176,28 @@ Once available, you can either copy or symlink the required files into the
 using the CLI arguments shown above.
 
 
-### Using `reader.py` to prepare an Elmer mesh with elevation data
+### Using `reader.py` to amend elevantion data to `examples/greenland_mesh_v0`
 
 The helper script `reader.py` can be used to combine an existing Elmer mesh with a DEM NetCDF file by replacing the z‑coordinates in `mesh.nodes` ahead of time. This can be useful if you want to preprocess a mesh once and reuse it for multiple EBFM runs.
 
 Assuming the example data has been copied into the `examples/` directory as described above, you can run the following command from the repository root:
 
 ```sh
-python3 src/ebfm/reader.py examples/MESH examples/BedMachineGreenland-v5_lo.nc --outpath examples/MESH_with_DEM --elmer-mesh-crs-epsg 3413
+python3 src/ebfm/reader.py examples/greenland_mesh_v0/MESH examples/BedMachineGreenland-v5.nc --outpath examples/greenland_mesh_v0_with_DEM/MESH --elmer-mesh-crs-epsg 3413
 ```
 
-This will write the updated mesh to a new directory. The path `examples/MESH_with_DEM` should not already exist. The original `examples/MESH` directory is copied and left unchanged.
+This will write the updated mesh to a new directory. The path `examples/greenland_mesh_v0_with_DEM` should not already exist. The original `examples/greenland_mesh_v0/MESH` directory is copied and left unchanged.
 
 Alternatively, you can modify the mesh directly in place, which overwrites `mesh.nodes`:
 
 ```sh
-python3 src/ebfm/reader.py examples/MESH examples/BedMachineGreenland-v5_lo.nc --in-place --elmer-mesh-crs-epsg 3413
+python3 src/ebfm/reader.py examples/greenland_mesh_v0/MESH examples/BedMachineGreenland-v5_lo.nc --in-place --elmer-mesh-crs-epsg 3413
 ```
 
 The resulting mesh can then be used directly with EBFM similar to the example with the MATLAB file from above:
 
 ```sh
-ebfm --elmer-mesh examples/MESH_with_DEM --elmer-mesh-crs-epsg 3413
+ebfm --elmer-mesh examples/greenland_mesh_v0_with_DEM/MESH --elmer-mesh-crs-epsg 3413
 ```
 
 ### Performance and Profiling Runs
@@ -293,12 +295,12 @@ Follow the install instructions from above and run the example command for a cou
 
 ```sh
 mpirun -np 1 ebfm \
-  --elmer-mesh $MESHES/MESH/partitioning.128/ \
+  --elmer-mesh $MESHES/greenland_mesh_v0/MESH/partitioning.128/ \
   --netcdf-mesh $DATA/BedMachineGreenland-v5.nc \
   --is-partitioned-elmer-mesh --use-part 1 \
   --coupler-config $CPL_CONFIG --couple-to-elmer --couple-to-icon \
   : \
-  -np 1 $ELMER_ROOT/src/elmer_dummy_f.x $MESHES/MESH/partitioning.128 1 $CPL_CONFIG \
+  -np 1 $ELMER_ROOT/src/elmer_dummy_f.x $MESHES/greenland_mesh_v0/MESH/partitioning.128 1 $CPL_CONFIG \
   : \
   -np 1 $ICON_ROOT/src/icon_dummy.x $MESHES/icon_grid_0054_R02B08_G.nc $DATA/mbe3064_atm_elmer_monmean_1979.nc $DATA/varlist_elmerfile
 ```

--- a/examples/greenland_mesh_v0/MESH/mesh.boundary
+++ b/examples/greenland_mesh_v0/MESH/mesh.boundary
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6aca9afcb3fcfef5b3f9571f12e5d0020325f01e22eb4f8633eb4dfe1d89094d
+size 607762

--- a/examples/greenland_mesh_v0/MESH/mesh.boundary.license
+++ b/examples/greenland_mesh_v0/MESH/mesh.boundary.license
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a40cf55dc5df60e2e2ae8a7b27e80d9e3b4d08421413120ccaa4d65ce40d6b12
+size 215

--- a/examples/greenland_mesh_v0/MESH/mesh.boundary.license
+++ b/examples/greenland_mesh_v0/MESH/mesh.boundary.license
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: ???? Elmer/Ice project
+# SPDX-FileCopyrightText: 2018 Elmer/Ice project
 #
 # SPDX-License-Identifier: CC-BY-4.0
 #

--- a/examples/greenland_mesh_v0/MESH/mesh.boundary.license
+++ b/examples/greenland_mesh_v0/MESH/mesh.boundary.license
@@ -1,3 +1,5 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a40cf55dc5df60e2e2ae8a7b27e80d9e3b4d08421413120ccaa4d65ce40d6b12
-size 215
+# SPDX-FileCopyrightText: ???? Elmer/Ice project
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#
+# SPDX-Comment: Downloaded greenland_mesh_v0 from https://elmerice.elmerfem.org/wiki/doku.php?id=eis:greenland on 2026-06-03

--- a/examples/greenland_mesh_v0/MESH/mesh.elements
+++ b/examples/greenland_mesh_v0/MESH/mesh.elements
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4532e2e2ca163aec95054b1943a2d987f82aadbfddecd9220a989fbcfeac10b6
+size 12699459

--- a/examples/greenland_mesh_v0/MESH/mesh.elements.license
+++ b/examples/greenland_mesh_v0/MESH/mesh.elements.license
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a40cf55dc5df60e2e2ae8a7b27e80d9e3b4d08421413120ccaa4d65ce40d6b12
+size 215

--- a/examples/greenland_mesh_v0/MESH/mesh.elements.license
+++ b/examples/greenland_mesh_v0/MESH/mesh.elements.license
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: ???? Elmer/Ice project
+# SPDX-FileCopyrightText: 2018 Elmer/Ice project
 #
 # SPDX-License-Identifier: CC-BY-4.0
 #

--- a/examples/greenland_mesh_v0/MESH/mesh.elements.license
+++ b/examples/greenland_mesh_v0/MESH/mesh.elements.license
@@ -1,3 +1,5 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a40cf55dc5df60e2e2ae8a7b27e80d9e3b4d08421413120ccaa4d65ce40d6b12
-size 215
+# SPDX-FileCopyrightText: ???? Elmer/Ice project
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#
+# SPDX-Comment: Downloaded greenland_mesh_v0 from https://elmerice.elmerfem.org/wiki/doku.php?id=eis:greenland on 2026-06-03

--- a/examples/greenland_mesh_v0/MESH/mesh.header
+++ b/examples/greenland_mesh_v0/MESH/mesh.header
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d77dca96707f82f377046dede70df3dfd9e37409054ef0667e5e9dc3a64d615d
+size 43

--- a/examples/greenland_mesh_v0/MESH/mesh.header.license
+++ b/examples/greenland_mesh_v0/MESH/mesh.header.license
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a40cf55dc5df60e2e2ae8a7b27e80d9e3b4d08421413120ccaa4d65ce40d6b12
+size 215

--- a/examples/greenland_mesh_v0/MESH/mesh.header.license
+++ b/examples/greenland_mesh_v0/MESH/mesh.header.license
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: ???? Elmer/Ice project
+# SPDX-FileCopyrightText: 2018 Elmer/Ice project
 #
 # SPDX-License-Identifier: CC-BY-4.0
 #

--- a/examples/greenland_mesh_v0/MESH/mesh.header.license
+++ b/examples/greenland_mesh_v0/MESH/mesh.header.license
@@ -1,3 +1,5 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a40cf55dc5df60e2e2ae8a7b27e80d9e3b4d08421413120ccaa4d65ce40d6b12
-size 215
+# SPDX-FileCopyrightText: ???? Elmer/Ice project
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#
+# SPDX-Comment: Downloaded greenland_mesh_v0 from https://elmerice.elmerfem.org/wiki/doku.php?id=eis:greenland on 2026-06-03

--- a/examples/greenland_mesh_v0/MESH/mesh.nodes
+++ b/examples/greenland_mesh_v0/MESH/mesh.nodes
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39aa2b35acef197fe617271f83b27e475020f7c364799ffb5b16805034dfb0ad
+size 15697665

--- a/examples/greenland_mesh_v0/MESH/mesh.nodes.license
+++ b/examples/greenland_mesh_v0/MESH/mesh.nodes.license
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a40cf55dc5df60e2e2ae8a7b27e80d9e3b4d08421413120ccaa4d65ce40d6b12
+size 215

--- a/examples/greenland_mesh_v0/MESH/mesh.nodes.license
+++ b/examples/greenland_mesh_v0/MESH/mesh.nodes.license
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: ???? Elmer/Ice project
+# SPDX-FileCopyrightText: 2018 Elmer/Ice project
 #
 # SPDX-License-Identifier: CC-BY-4.0
 #

--- a/examples/greenland_mesh_v0/MESH/mesh.nodes.license
+++ b/examples/greenland_mesh_v0/MESH/mesh.nodes.license
@@ -1,3 +1,5 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a40cf55dc5df60e2e2ae8a7b27e80d9e3b4d08421413120ccaa4d65ce40d6b12
-size 215
+# SPDX-FileCopyrightText: ???? Elmer/Ice project
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#
+# SPDX-Comment: Downloaded greenland_mesh_v0 from https://elmerice.elmerfem.org/wiki/doku.php?id=eis:greenland on 2026-06-03


### PR DESCRIPTION
This PR adds the Elmer mesh that we use in our example directly in this repository for more conveniently running the examples.

@tzwinger I hope everything is fine with the way how we credit the Elmer Mesh file.

# Author's Todos

- [x] I ran the [pre-commit hooks](https://github.com/EBFMorg/EBFM?tab=readme-ov-file#developer-notes) and fixed all issues
- [x] I added an entry under *develop* in the [CHANGELOG.md](https://github.com/EBFMorg/EBFM/blob/main/CHANGELOG.md) (may be skipped for minor changes not observable for the user)
