### PR TITLE
Add reduced-size BedMachine NetCDF example and NetCDF tooling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,6 @@
 
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Files tracked with git LFS
+examples/BedMachineGreenland-v5_lo.nc filter=lfs diff=lfs merge=lfs -text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ SPDX-License-Identifier: CC-BY-4.0
 # develop
 
 * Revise helper script `reader.py`. https://github.com/EBFMorg/EBFM/pull/119.
+* Add reduced-size BedMachine Greenland NetCDF example (`examples/BedMachineGreenland-v5_lo.nc`) and two utility scripts under `tools/`: `nc_reduce_size.py` to produce smaller NetCDF copies (field selection and grid subsampling), and `nc_2_vtk.py` to convert NetCDF fields to VTK for visualisation in ParaView. https://github.com/EBFMorg/EBFM/pull/123.
 * Bug fixes in double depth method in INIT.py and LOOP_SNOW.py
 * Implement MPI handshake for comm splitting. https://github.com/EBFMorg/EBFM/pull/88.
 * EBFM now only adds metadata to fields where this is explicitly specified. Note: This can lead to failures in components that do not properly guard `get_metadata` calls with `has_metadata` checks. https://github.com/EBFMorg/EBFM/pull/102

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ of the input x/y coordinates. EBFM uses this CRS to convert coordinates to lon/l
   Usage example:
 
   ```sh
-  ebfm --elmer-mesh examples/MESH --netcdf-mesh examples/BedMachineGreenland-v5.nc --elmer-mesh-crs-epsg 3413
+  ebfm --elmer-mesh examples/MESH --netcdf-mesh examples/BedMachineGreenland-v5_lo.nc --elmer-mesh-crs-epsg 3413
   ```
 
 Note that an Elmer mesh must be provided in a directory following the structure:
@@ -154,14 +154,24 @@ path/to/your/elmer/MESH
 Usage example for partitioned mesh:
 
 ```sh
-ebfm --elmer-mesh examples/MESH/partitioning.128/ --netcdf-mesh examples/BedMachineGreenland-v5.nc --is-partitioned-elmer-mesh --use-part 42
+ebfm --elmer-mesh examples/MESH/partitioning.128/ --netcdf-mesh examples/BedMachineGreenland-v5_lo.nc --is-partitioned-elmer-mesh --use-part 42
 ```
 
 ### Getting the example data
 
-The example inputs and datasets referenced above (e.g. `BedMachineGreenland-v5.nc` or `MESH`) can be obtained from the [TerraDT testcase repository](https://gitlab.dkrz.de/TerraDT/testcase). Please note that access to this repository may need to be requested, and you must have access to the Levante supercomputer at DKRZ.
+A reduced-resolution NetCDF file (`examples/BedMachineGreenland-v5_lo.nc`) is
+included directly in this repository and can be used as a drop-in for quick
+testing. See [`examples/README.md`](examples/README.md) for details on how it
+was derived from the original dataset.
 
-Once available, you can either copy or symlink the required files into the `examples/` directory of this repository, or point EBFM to their locations using the CLI arguments shown above.
+For the full-resolution dataset and the example Elmer mesh (`MESH`), refer to
+the [TerraDT testcase repository](https://gitlab.dkrz.de/TerraDT/testcase).
+Note that access to that repository may need to be requested and requires
+access to the Levante supercomputer at DKRZ.
+
+Once available, you can either copy or symlink the required files into the
+`examples/` directory of this repository, or point EBFM to their locations
+using the CLI arguments shown above.
 
 
 ### Using `reader.py` to prepare an Elmer mesh with elevation data
@@ -171,7 +181,7 @@ The helper script `reader.py` can be used to combine an existing Elmer mesh with
 Assuming the example data has been copied into the `examples/` directory as described above, you can run the following command from the repository root:
 
 ```sh
-python3 src/ebfm/reader.py examples/MESH examples/BedMachineGreenland-v5.nc --outpath examples/MESH_with_DEM --elmer-mesh-crs-epsg 3413
+python3 src/ebfm/reader.py examples/MESH examples/BedMachineGreenland-v5_lo.nc --outpath examples/MESH_with_DEM --elmer-mesh-crs-epsg 3413
 ```
 
 This will write the updated mesh to a new directory. The path `examples/MESH_with_DEM` should not already exist. The original `examples/MESH` directory is copied and left unchanged.
@@ -179,7 +189,7 @@ This will write the updated mesh to a new directory. The path `examples/MESH_wit
 Alternatively, you can modify the mesh directly in place, which overwrites `mesh.nodes`:
 
 ```sh
-python3 src/ebfm/reader.py examples/MESH examples/BedMachineGreenland-v5.nc --in-place --elmer-mesh-crs-epsg 3413
+python3 src/ebfm/reader.py examples/MESH examples/BedMachineGreenland-v5_lo.nc --in-place --elmer-mesh-crs-epsg 3413
 ```
 
 The resulting mesh can then be used directly with EBFM similar to the example with the MATLAB file from above:

--- a/examples/BedMachineGreenland-v5_lo.nc.license
+++ b/examples/BedMachineGreenland-v5_lo.nc.license
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2026 The EBFM Authors
+#
+# SPDX-License-Identifier: CC-BY-4.0
+#
+# SPDX-Comment: Derived from:
+# SPDX-Comment: Author: Morlighem, M.
+# SPDX-Comment: Title: IceBridge BedMachine Greenland, Version 5
+# SPDX-Comment: Publisher: NASA National Snow and Ice Data Center DAAC
+# SPDX-Comment: Year: 2022
+# SPDX-Comment: URL: https://nsidc.org/data/idbmg4/versions/5
+# SPDX-Comment: DOI: 10.5067/GMEVBWFLSGIW

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,33 @@
+<!--
+SPDX-FileCopyrightText: 2026 EBFM Authors
+
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
+# Example Files
+
+| File                           | Description                                    |
+|------------------------------- | ---------------------------------------------- |
+| `BedMachineGreenland-v5_lo.nc` | Low-res version of `BedMachineGreenland-v5.nc` |
+| `dem_and_mask.mat`             | MATLAB example grid                            |
+
+### How `BedMachineGreenland-v5_lo.nc` was produced
+
+`BedMachineGreenland-v5_lo.nc` is a low-resolution subset of the
+[`BedMachineGreenland-v5.nc`](https://nsidc.org/data/idbmg4/versions/5) dataset (Morlighem, 2022) provided as an
+alternative if you cannot or do not want to download the rather large dataset from the original source.
+
+The low-resolution file only contains the `surface` field (ice surface elevation, EPSG:3413) and subsamples the
+original 150 m grid by a factor of 10, giving a 1022 x 1835 point grid at ~1500 m effective resolution. To reproduce
+from the original file, please download [`BedMachineGreenland-v5.nc`](https://nsidc.org/data/idbmg4/versions/5) and
+then run:
+
+```bash
+python3 tools/nc_reduce_size.py \
+    BedMachineGreenland-v5.nc \
+    --keep-only surface \
+    --stride 10 \
+    -o examples/BedMachineGreenland-v5_lo.nc
+```
+
+See `tools/README.md` for full documentation of `nc_reduce_size.py`.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,60 @@
+<!--
+SPDX-FileCopyrightText: 2026 EBFM Authors
+
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
+# Tools
+
+Utility scripts for working with BedMachine-style NetCDF files.
+
+---
+
+## `nc_reduce_size.py` - shrink a NetCDF file
+
+Produces a smaller copy of a NetCDF file by dropping unwanted data fields
+and/or subsampling the grid.  Global attributes, the CRS (`mapping`), and the
+grid axes (`x`, `y`) are always preserved so the output remains fully
+self-describing.
+
+```bash
+# Keep only the surface field (3.6 GB -> 750 MB)
+python tools/nc_reduce_size.py input.nc --keep-only surface
+
+# Keep surface and bed at 10x reduced resolution (3.6 GB -> ~15 MB)
+python tools/nc_reduce_size.py input.nc --keep-only surface bed --stride 10
+
+# Reduce grid resolution for all fields without dropping any
+python tools/nc_reduce_size.py input.nc --stride 5
+
+# Custom output path
+python tools/nc_reduce_size.py input.nc --keep-only surface --stride 10 -o lofi.nc
+```
+
+---
+
+## `nc_2_vtk.py` - convert NetCDF fields to VTK for ParaView
+
+Reads one or more 2-D fields from a NetCDF file and writes a VTK legacy binary
+rectilinear grid (`.vtk`) using the native projected x/y coordinates.  Each
+field becomes a named point-data array, selectable in ParaView.
+
+```bash
+# Export the surface field at full resolution
+python tools/nc_2_vtk.py input.nc --keep-only surface
+
+# Fast preview: surface + bed at 10x reduced resolution (~2 M points)
+python tools/nc_2_vtk.py input.nc --keep-only surface bed --stride 10
+
+# Export all 2-D fields at full resolution
+python tools/nc_2_vtk.py input.nc
+
+# Custom output path
+python tools/nc_2_vtk.py input.nc --keep-only surface --stride 10 -o surface.vtk
+```
+
+Open the resulting `.vtk` file in ParaView:
+
+```bash
+paraview surface.vtk
+```

--- a/tools/nc_2_vtk.py
+++ b/tools/nc_2_vtk.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: 2026 EBFM Authors
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Convert 2-D fields from a NetCDF file to a VTK legacy binary rectilinear grid.
+
+Each selected field is written as a named point-data array on a flat (z=0) grid
+using the native projected x/y coordinates from the file.  The output can be
+opened directly in ParaView or any other VTK-capable visualisation tool.
+
+Grid infrastructure variables (x, y) are always read and used as grid axes.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import netCDF4
+import numpy as np
+import vtk
+from vtk.util.numpy_support import numpy_to_vtk
+
+# Variables treated as grid axes, not data fields
+GRID_VARS = {"x", "y", "mapping"}
+
+
+def netcdf_to_vtk(
+    nc_path: Path,
+    out_path: Path,
+    fields: list[str] | None = None,
+    stride: int = 1,
+) -> None:
+    """Read 2-D fields from a NetCDF file and write a VTK legacy binary rectilinear grid.
+
+    Args:
+        nc_path:  Path to the input NetCDF file.
+        out_path: Path for the output .vtk file.
+        fields:   List of 2-D variable names to embed as point-data arrays.
+                  None means include all 2-D fields.
+        stride:   Subsampling stride in both x and y (e.g. 10 -> every 10th point).
+    """
+    with netCDF4.Dataset(nc_path) as nc:
+        all_fields = sorted(
+            name for name, v in nc.variables.items() if name not in GRID_VARS and set(v.dimensions) >= {"x", "y"}
+        )
+
+        if fields is not None:
+            unknown = [f for f in fields if f not in all_fields]
+            if unknown:
+                raise ValueError(
+                    f"field(s) not found in {nc_path.name}: {unknown}\n" f"Available 2-D fields: {all_fields}"
+                )
+            selected_fields = fields
+        else:
+            selected_fields = all_fields
+
+        x = np.asarray(nc["x"][::stride], dtype=np.float64)
+        y = np.asarray(nc["y"][::stride], dtype=np.float64)
+        data = {name: np.asarray(nc[name][::stride, ::stride], dtype=np.float32) for name in selected_fields}
+
+    # z-axis is a single plane at z=0; field values are stored as point data.
+    z = np.array([0.0], dtype=np.float64)
+
+    grid = vtk.vtkRectilinearGrid()
+    grid.SetDimensions(len(x), len(y), 1)
+    grid.SetXCoordinates(numpy_to_vtk(x, deep=True, array_type=vtk.VTK_DOUBLE))
+    grid.SetYCoordinates(numpy_to_vtk(y, deep=True, array_type=vtk.VTK_DOUBLE))
+    grid.SetZCoordinates(numpy_to_vtk(z, deep=True, array_type=vtk.VTK_DOUBLE))
+
+    for i, (name, arr) in enumerate(data.items()):
+        # VTK expects points ordered x-fastest, y-next (row-major / C order).
+        vtk_array = numpy_to_vtk(arr.ravel(order="C"), deep=True, array_type=vtk.VTK_FLOAT)
+        vtk_array.SetName(name)
+        if i == 0:
+            grid.GetPointData().SetScalars(vtk_array)
+        else:
+            grid.GetPointData().AddArray(vtk_array)
+
+    # Use legacy binary format - robust across VTK/ParaView version differences.
+    writer = vtk.vtkRectilinearGridWriter()
+    writer.SetFileName(str(out_path))
+    writer.SetInputData(grid)
+    writer.SetFileTypeToBinary()
+    writer.Write()
+
+    print(f"Written : {out_path}")
+    print(f"  Fields  : {selected_fields}")
+    print(f"  Grid    : {len(x)} x {len(y)} points  (stride {stride})")
+    print(f"  x range : {x.min():.0f} - {x.max():.0f} m")
+    print(f"  y range : {y.min():.0f} - {y.max():.0f} m")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Convert 2-D NetCDF fields to a VTK rectilinear grid for visualisation in ParaView.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  # Export the surface field at full resolution\n"
+            "  %(prog)s input.nc --keep-only surface\n\n"
+            "  # Export surface and bed at 10x reduced resolution (fast preview)\n"
+            "  %(prog)s input.nc --keep-only surface bed --stride 10\n\n"
+            "  # Export all 2-D fields\n"
+            "  %(prog)s input.nc\n"
+        ),
+    )
+    parser.add_argument("nc_file", type=Path, help="Input NetCDF file.")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="Output .vtk path (default: input stem + .vtk in the same directory).",
+    )
+    parser.add_argument(
+        "--keep-only",
+        nargs="+",
+        metavar="FIELD",
+        default=None,
+        help=(
+            "2-D field(s) to include in the VTK file (e.g. --keep-only surface bed). "
+            "Omit to include all 2-D fields found in the file."
+        ),
+    )
+    parser.add_argument(
+        "--stride",
+        type=int,
+        default=1,
+        metavar="N",
+        help=(
+            "Subsample every N-th point in x and y, reducing point count by N². "
+            "Useful for fast previews (e.g. --stride 10 gives ~100x fewer points). "
+            "Default: 1 (full resolution)."
+        ),
+    )
+    args = parser.parse_args()
+
+    out = args.output if args.output is not None else args.nc_file.with_suffix(".vtk")
+
+    try:
+        netcdf_to_vtk(args.nc_file, out, fields=args.keep_only, stride=args.stride)
+    except ValueError as err:
+        print(f"Error: {err}", file=sys.stderr)
+        sys.exit(1)

--- a/tools/nc_reduce_size.py
+++ b/tools/nc_reduce_size.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: 2026 EBFM Authors
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Reduce the size of a BedMachine-style NetCDF file.
+
+Produces a smaller copy by optionally dropping unwanted data fields and/or
+subsampling the x/y grid at a given stride.  Global attributes, the CRS
+variable (mapping), and the grid axes (x, y) are always preserved so the
+output remains a fully self-describing NetCDF file.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import netCDF4
+
+# Always-kept infrastructure variables (CRS + grid axes)
+GRID_VARS = {"mapping", "x", "y"}
+
+
+def strip_netcdf(
+    in_path: Path,
+    out_path: Path,
+    keep_only: list[str] | None = None,
+    stride: int = 1,
+) -> None:
+    """Copy selected fields from a NetCDF file to a new, smaller file.
+
+    Args:
+        in_path:   Path to the source NetCDF file.
+        out_path:  Path for the output NetCDF file.
+        keep_only: Data field names to keep. None means keep all data fields.
+        stride:    Subsampling stride applied to both x and y axes.
+    """
+    with netCDF4.Dataset(in_path, "r") as src:
+        # Determine which variables are "data fields" (2-D, on the x/y grid)
+        all_fields = sorted(
+            name for name, v in src.variables.items() if name not in GRID_VARS and set(v.dimensions) >= {"x", "y"}
+        )
+
+        if keep_only is not None:
+            unknown = [f for f in keep_only if f not in all_fields]
+            if unknown:
+                raise ValueError(
+                    f"field(s) not found in {in_path.name}: {unknown}\n" f"Available 2-D fields: {all_fields}"
+                )
+            fields_to_write = keep_only
+        else:
+            fields_to_write = all_fields
+
+        keep_vars = GRID_VARS | set(fields_to_write)
+
+        with netCDF4.Dataset(out_path, "w", format=src.file_format) as dst:
+            # Global attributes — copy originals, then append a provenance note
+            dst.setncatts({a: src.getncattr(a) for a in src.ncattrs()})
+            original_name = in_path.name
+            kept = ", ".join(sorted(fields_to_write))
+            dst.history = (
+                f"Reduced from {original_name} using tools/nc_reduce_size.py from https://github.com/EBFMorg/EBFM."
+                f" (stride={stride}, kept fields: {kept})" + (getattr(dst, "history", "") or "")
+            ).strip()
+
+            # Dimensions - resized when stride > 1
+            for name, dim in src.dimensions.items():
+                if name in ("x", "y"):
+                    new_len = len(src.variables[name][::stride])
+                    dst.createDimension(name, new_len)
+                else:
+                    dst.createDimension(name, None if dim.isunlimited() else len(dim))
+
+            # Write selected variables
+            for name in keep_vars:
+                if name not in src.variables:
+                    continue
+                sv = src.variables[name]
+                attrs = {a: sv.getncattr(a) for a in sv.ncattrs() if a != "_FillValue"}
+                fill = sv.getncattr("_FillValue") if "_FillValue" in sv.ncattrs() else None
+
+                dv = dst.createVariable(name, sv.dtype, sv.dimensions, fill_value=fill)
+                dv.setncatts(attrs)
+
+                # Apply stride on x/y dimensions
+                if sv.dimensions == ("y", "x"):
+                    dv[:] = sv[::stride, ::stride]
+                elif sv.dimensions == ("y",):
+                    dv[:] = sv[::stride]
+                elif sv.dimensions == ("x",):
+                    dv[:] = sv[::stride]
+                else:
+                    dv[:] = sv[:]
+
+        # Collect reporting info before src closes
+        src_x_len = len(src.variables["x"][::stride])
+        src_y_len = len(src.variables["y"][::stride])
+        total_size = sum(v[:].nbytes for v in src.variables.values())
+        dropped = sorted(set(src.variables) - keep_vars)
+
+    with netCDF4.Dataset(out_path, "r") as dst:
+        out_size = sum(v[:].nbytes for v in dst.variables.values())
+
+    print(f"Written: {out_path}")
+    print(f"  Kept fields    : {sorted(fields_to_write)}")
+    if dropped:
+        print(f"  Dropped fields : {dropped}")
+    print(f"  Stride         : {stride}  ->  grid {src_x_len} x {src_y_len}")
+    print(f"  Data size      : {out_size / 1e6:.1f} MB  (was {total_size / 1e6:.1f} MB)")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Produce a smaller copy of a BedMachine-style NetCDF file.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  # Keep only the surface field at full resolution\n"
+            "  %(prog)s input.nc --keep-only surface\n\n"
+            "  # Keep surface and bed at 10x reduced resolution\n"
+            "  %(prog)s input.nc --keep-only surface bed --stride 10\n\n"
+            "  # Keep all fields but reduce grid resolution by 5x\n"
+            "  %(prog)s input.nc --stride 5\n"
+        ),
+    )
+    parser.add_argument("input", type=Path, help="Source NetCDF file.")
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="Output NetCDF path (default: <input stem>_lofi.nc in the same directory).",
+    )
+    parser.add_argument(
+        "--keep-only",
+        nargs="+",
+        metavar="FIELD",
+        default=None,
+        help=(
+            "Data field(s) to retain (e.g. --keep-only surface bed). "
+            "Grid variables (x, y, mapping) are always kept. "
+            "Omit to retain all data fields."
+        ),
+    )
+    parser.add_argument(
+        "--stride",
+        type=int,
+        default=1,
+        metavar="N",
+        help=(
+            "Subsample every N-th point in x and y, reducing point count by N*N. "
+            "E.g. --stride 10 gives ~100X fewer grid points. "
+            "Default: 1 (full resolution)."
+        ),
+    )
+    args = parser.parse_args()
+
+    out = args.output if args.output is not None else args.input.with_stem(args.input.stem + "_reduced")
+    if out.exists():
+        print(f"Error: output file already exists: {out}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        strip_netcdf(args.input, out, keep_only=args.keep_only, stride=args.stride)
+    except ValueError as err:
+        print(f"Error: {err}", file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
Adds a low-resolution (stride=10, surface only) version of the BedMachine Greenland v5 dataset under examples/ so users without access to the full ~3.5 GB file can still run and test the codebase.

Two utility scripts are added under tools/:
- nc_reduce_size.py: produce a smaller NetCDF copy by selecting fields (--keep-only) and/or subsampling the grid (--stride).
- nc_2_vtk.py: convert 2-D NetCDF fields to a VTK legacy binary rectilinear grid for visualisation in ParaView.

Both tools and the example files are documented in their respective README.md files.

# Author's Todos

- [x] I ran the [pre-commit hooks](https://github.com/EBFMorg/EBFM?tab=readme-ov-file#developer-notes) and fixed all issues
- [x] I added an entry under *develop* in the [CHANGELOG.md](https://github.com/EBFMorg/EBFM/blob/main/CHANGELOG.md) (may be skipped for minor changes not observable for the user)
