### PR TITLE
Generalize file writing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,14 @@ Output/*.nc
 Reboot/*.nc
 .coverage
 .tox
+.idea/EBFM_with_YAC.iml
+.idea/inspectionProfiles/profiles_settings.xml
+.idea/misc.xml
+.idea/vcs.xml
+.idea/workspace.xml
+examples/1990_1.nc
+examples/1990_2.nc
+examples/add_mask_field_to_greenland_grid.py
+examples/createLowResGreenlandExperiment.py
+examples/download_CARRA2.py
+examples/preprocess_greenland_forcing_files.py

--- a/Output/Plot_variables_on_unstructured_grid.py
+++ b/Output/Plot_variables_on_unstructured_grid.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 EBFM Authors
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import netCDF4
+import matplotlib.pyplot as plt
+import matplotlib.tri as mtri
+
+nc = netCDF4.Dataset("model_output.nc")
+
+xv = nc["x_vertex"][:]
+yv = nc["y_vertex"][:]
+triangles = nc["cell_vertices"][:]
+smb = nc["smb"][0, :]
+
+triangulation = mtri.Triangulation(xv, yv, triangles)
+
+plt.tripcolor(triangulation, facecolors=smb, shading="flat")
+plt.colorbar(label="smb")
+plt.gca().set_aspect("equal")
+plt.show()

--- a/src/ebfm/core/INIT.py
+++ b/src/ebfm/core/INIT.py
@@ -236,6 +236,7 @@ def init_grid(grid: GridDict, io, config: GridConfig):
 
         grid["x"], grid["y"] = mesh.x_cells, mesh.y_cells
         grid["lat"], grid["lon"] = mesh.lat_cells, mesh.lon_cells
+
         logger.debug("Reading DEM from file and interpolating to grid...")
         if config.grid_type is GridInputType.CUSTOM:
             logger.debug("... for grid type CUSTOM.")
@@ -248,9 +249,10 @@ def init_grid(grid: GridDict, io, config: GridConfig):
             min_thickness_glacier = 1.0  # minimum ice thickness to consider grid cell as glacier (m)
             grid["mask"] = (h_cells > min_thickness_glacier).astype(int)
 
+        grid["lat"], grid["lon"] = np.degrees(mesh.lat_cells), np.degrees(mesh.lon_cells)
+
         if "mask" not in grid:
             grid["mask"] = np.ones_like(grid["x"])  # treats every grid cell as glacier
-
         if config.grid_type is GridInputType.ELMERXIOS:
             grid["gpsum"] = grid["z"].shape[0]
         else:

--- a/src/ebfm/core/INIT.py
+++ b/src/ebfm/core/INIT.py
@@ -235,7 +235,6 @@ def init_grid(grid: GridDict, io, config: GridConfig):
             )
 
         grid["x"], grid["y"] = mesh.x_cells, mesh.y_cells
-        grid["lat"], grid["lon"] = mesh.lat_cells, mesh.lon_cells
 
         logger.debug("Reading DEM from file and interpolating to grid...")
         if config.grid_type is GridInputType.CUSTOM:

--- a/src/ebfm/core/LOOP_write_to_file.py
+++ b/src/ebfm/core/LOOP_write_to_file.py
@@ -8,6 +8,137 @@ from netCDF4 import Dataset, date2num
 
 from .LOOP_general_functions import is_first_time_step, is_final_time_step
 
+_FILL_VALUE = -9999.0
+
+
+def _write_unstructured_grid(nc_file, grid):
+    """Write unstructured mesh coordinates and topology to an open NetCDF file."""
+    n_cells = grid["x"].shape[0]
+
+    nc_file.createDimension("cell", n_cells)
+
+    x = nc_file.createVariable("x", np.float64, ("cell",))
+    y = nc_file.createVariable("y", np.float64, ("cell",))
+    z = nc_file.createVariable("z", np.float64, ("cell",))
+    lon = nc_file.createVariable("lon", np.float64, ("cell",))
+    lat = nc_file.createVariable("lat", np.float64, ("cell",))
+
+    x[:] = grid["x"]
+    y[:] = grid["y"]
+    z[:] = grid["z"]
+    lon[:] = grid["lon"]
+    lat[:] = grid["lat"]
+
+    x.units = "m"
+    y.units = "m"
+    z.units = "m"
+    lon.units = "degrees_east"
+    lat.units = "degrees_north"
+
+    x.description = "Cell-center x coordinate"
+    y.description = "Cell-center y coordinate"
+    z.description = "Cell-center surface elevation"
+    lon.description = "Cell-center longitude"
+    lat.description = "Cell-center latitude"
+
+    mesh = grid.get("mesh")
+    if mesh is None:
+        return
+
+    n_vertices = mesh.x_vertices.shape[0]
+    vertices_per_cell = mesh.cell_to_vertex.shape[1]
+
+    nc_file.createDimension("vertex", n_vertices)
+    nc_file.createDimension("nv", vertices_per_cell)
+
+    vx = nc_file.createVariable("x_vertex", np.float64, ("vertex",))
+    vy = nc_file.createVariable("y_vertex", np.float64, ("vertex",))
+    vz = nc_file.createVariable("z_vertex", np.float64, ("vertex",))
+    vlon = nc_file.createVariable("lon_vertex", np.float64, ("vertex",))
+    vlat = nc_file.createVariable("lat_vertex", np.float64, ("vertex",))
+    cell_vertices = nc_file.createVariable("cell_vertices", np.int32, ("cell", "nv"))
+
+    vx[:] = mesh.x_vertices
+    vy[:] = mesh.y_vertices
+    vz[:] = mesh.z_vertices
+    vlon[:] = np.degrees(mesh.lon_vertices)
+    vlat[:] = np.degrees(mesh.lat_vertices)
+    cell_vertices[:, :] = mesh.cell_to_vertex.astype(np.int32)
+
+    vx.units = "m"
+    vy.units = "m"
+    vz.units = "m"
+    vlon.units = "degrees_east"
+    vlat.units = "degrees_north"
+
+    cell_vertices.description = "Zero-based local vertex indices for each unstructured cell"
+
+
+def _write_structured_grid(nc_file, grid):
+    """Write structured grid dimensions and coordinates to an open NetCDF file."""
+    nc_file.createDimension("y", grid["x_2D"].shape[0])
+    nc_file.createDimension("x", grid["x_2D"].shape[1])
+
+    x = nc_file.createVariable("x", np.float64, ("y", "x"))
+    y = nc_file.createVariable("y", np.float64, ("y", "x"))
+
+    x[:, :] = grid["x_2D"]
+    y[:, :] = grid["y_2D"]
+
+    x.units = "m"
+    y.units = "m"
+
+    x.description = "Structured grid x coordinate"
+    y.description = "Structured grid y coordinate"
+
+    if "z_2D" in grid:
+        z = nc_file.createVariable("z", np.float64, ("y", "x"))
+        z[:, :] = grid["z_2D"]
+        z.units = "m"
+        z.description = "Structured grid surface elevation"
+
+    if "lon_2D" in grid and "lat_2D" in grid:
+        lon = nc_file.createVariable("lon", np.float64, ("y", "x"))
+        lat = nc_file.createVariable("lat", np.float64, ("y", "x"))
+        lon[:, :] = grid["lon_2D"]
+        lat[:, :] = grid["lat_2D"]
+        lon.units = "degrees_east"
+        lat.units = "degrees_north"
+        lon.description = "Structured grid longitude"
+        lat.description = "Structured grid latitude"
+
+
+def _output_dimensions(varname, grid):
+    """Return NetCDF dimensions/chunking for a model output variable."""
+    if grid["is_unstructured"]:
+        if varname.startswith("sub"):
+            return ("time", "cell", "nl"), (1, grid["x"].shape[0], grid["nl"])
+        return ("time", "cell"), (1, grid["x"].shape[0])
+
+    if varname.startswith("sub"):
+        return ("time", "y", "x", "nl"), (1, grid["x_2D"].shape[0], grid["x_2D"].shape[1], grid["nl"])
+    return ("time", "y", "x"), (1, grid["x_2D"].shape[0], grid["x_2D"].shape[1])
+
+
+def _write_output_variable(nc_file, varname, var_1D, time_index, grid):
+    """Write one model output variable to an open NetCDF file."""
+    if grid["is_unstructured"]:
+        if varname.startswith("sub"):
+            nc_file[varname][time_index, :, :] = var_1D
+        else:
+            nc_file[varname][time_index, :] = var_1D
+        return
+
+    if varname.startswith("sub"):
+        var_3D = np.full((grid["x_2D"].size, grid["nl"]), _FILL_VALUE)
+        var_3D[grid["ind"], :] = var_1D
+        var_4D = var_3D.reshape(-1, grid["nl"]).reshape(*grid["x_2D"].shape, grid["nl"])
+        nc_file[varname][time_index, :, :, :] = var_4D
+    else:
+        var_2D = np.full(grid["x_2D"].shape, _FILL_VALUE)
+        var_2D.flat[grid["ind"]] = var_1D
+        nc_file[varname][time_index, :, :] = var_2D
+
 
 def main(OUTFILE, io, OUT, grid, t, time):
     # Specify variables to be written
@@ -120,18 +251,11 @@ def main(OUTFILE, io, OUT, grid, t, time):
 
     def save_netCDF_file():
         """
-        Save model output stored in OUTFILE to a NetCDF file. Converts 1D data to 2D grids.
+        Save model output stored in OUTFILE to a NetCDF file.
 
-        Parameters:
-        - OUTFILE: Dictionary storing output details and temporary data.
-        - io: Dictionary holding I/O parameters, e.g., freqout, outdir.
-        - grid: Grid information (e.g., x_2D size and ind: mapping 1D -> 2D).
-        - t: Current time step.
-        - time: Dictionary containing time-related variables.
-        - freqout: Frequency of output (save interval).
-
-        Returns:
-        - Updated io dictionary with NetCDF file reference.
+        Structured grids are written on dimensions (time, y, x).
+        Unstructured grids are written on dimensions (time, cell), with
+        optional mesh topology if grid["mesh"] is available.
         """
         # Epoch for time variable
         time_units = "days since 1970-01-01 00:00:00"
@@ -148,12 +272,9 @@ def main(OUTFILE, io, OUT, grid, t, time):
             io["nc_file"].createDimension("time", None)  # Unlimited time dimension
 
             if grid["is_unstructured"]:
-                # Define dimensions
-                io["nc_file"].createDimension("y", grid["lat"].shape[0])  # 2D grid rows
-            else:  # structured grid
-                # Define dimensions
-                io["nc_file"].createDimension("y", grid["x_2D"].shape[0])  # 2D grid rows
-                io["nc_file"].createDimension("x", grid["x_2D"].shape[1])  # 2D grid columns
+                _write_unstructured_grid(io["nc_file"], grid)
+            else:
+                _write_structured_grid(io["nc_file"], grid)
 
             io["nc_file"].createDimension("nl", grid["nl"])  # Vertical layers for `sub` variables
 
@@ -163,29 +284,7 @@ def main(OUTFILE, io, OUT, grid, t, time):
                 var_units = entry[1]
                 var_desc = entry[3]
 
-                dimensions: tuple
-                chunksizes: tuple
-
-                if grid["is_unstructured"]:
-                    # Check if variable is a `sub` variable
-                    if varname.startswith("sub"):
-                        # Define variable as 3D: (time, y, nl)
-                        dimensions = ("time", "y", "nl")
-                        chunksizes = (1, grid["lat"].shape[0], grid["nl"])
-                    else:
-                        # Define variable as 2D: (time, y)
-                        dimensions = ("time", "y")
-                        chunksizes = (1, grid["lat"].shape[0])
-                else:
-                    # Check if variable is a `sub` variable
-                    if varname.startswith("sub"):
-                        # Define variable as 4D: (time, y, x, nl)
-                        dimensions = ("time", "y", "x", "nl")
-                        chunksizes = (1, grid["x_2D"].shape[0], grid["x_2D"].shape[1], grid["nl"])
-                    else:
-                        # Define variable as 3D: (time, y, x)
-                        dimensions = ("time", "y", "x")
-                        chunksizes = (1, grid["x_2D"].shape[0], grid["x_2D"].shape[1])
+                dimensions, chunksizes = _output_dimensions(varname, grid)
 
                 nc_var = io["nc_file"].createVariable(
                     varname=varname,
@@ -193,22 +292,23 @@ def main(OUTFILE, io, OUT, grid, t, time):
                     dimensions=dimensions,
                     zlib=True,
                     complevel=4,
-                    fill_value=-9999.0,  # Fill missing values
+                    fill_value=_FILL_VALUE,
                     chunksizes=chunksizes,
                 )
+
                 # Assign metadata
                 nc_var.units = var_units
                 nc_var.description = var_desc
 
             # Define a time variable to track simulation steps
-            nc_time = io["nc_file"].createVariable("time", np.float64, ("time",), zlib=True, fill_value=-9999.0)
+            nc_time = io["nc_file"].createVariable("time", np.float64, ("time",), zlib=True, fill_value=_FILL_VALUE)
             nc_time.units = time_units
             nc_time.calendar = time_calendar
             nc_time.description = "Time at which data is recorded, in days since 1970-01-01 00:00:00"
 
-        # Write data to NetCDF at the specified frequency (e.g., for average/summed values)
+        # Write data to NetCDF at the specified frequency
         if (t + 1) % io["freqout"] == 0:  # TODO: correct?
-            time_index = t // io["freqout"]  # Determine the time slice index
+            time_index = t // io["freqout"]
 
             # Calculate time in "days since 1970-01-01"
             time_days_since_1970 = date2num(time["TCUR"], units=time_units, calendar=time_calendar)
@@ -219,18 +319,8 @@ def main(OUTFILE, io, OUT, grid, t, time):
             # Write variables to NetCDF
             for entry in OUTFILE["varsout"]:
                 varname = entry[0]
-                var_1D = OUTFILE["TEMP"][varname]  # 1D data
-
-                # Handle `sub` variables (4D: time, y, x, nl)
-                if varname.startswith("sub"):
-                    var_3D = np.full((grid["x_2D"].size, grid["nl"]), -9999.0)
-                    var_3D[grid["ind"], :] = var_1D
-                    var_4D = var_3D.reshape(-1, grid["nl"]).reshape(*grid["x_2D"].shape, grid["nl"])
-                    io["nc_file"][varname][time_index, :, :, :] = var_4D
-                else:
-                    var_2D = np.full(grid["x_2D"].shape, -9999.0)
-                    var_2D.flat[grid["ind"]] = var_1D
-                    io["nc_file"][varname][time_index, :, :] = var_2D
+                var_1D = OUTFILE["TEMP"][varname]
+                _write_output_variable(io["nc_file"], varname, var_1D, time_index, grid)
 
         # Close the NetCDF file at the final time step
         if is_final_time_step(t, time):

--- a/src/ebfm/core/config/grid.py
+++ b/src/ebfm/core/config/grid.py
@@ -85,7 +85,7 @@ class GridConfig:
             self.grid_type = GridInputType.CUSTOM
             self.mesh_file = elmer_mesh
             self.dem_file = args.netcdf_dem_mesh
-            self.is_unstructured = False
+            self.is_unstructured = True
         elif args.netcdf_dem_mesh_unstructured and elmer_mesh:
             self.grid_type = GridInputType.ELMERXIOS
             self.mesh_file = elmer_mesh
@@ -94,7 +94,7 @@ class GridConfig:
         elif elmer_mesh:
             self.grid_type = GridInputType.ELMER
             self.mesh_file = elmer_mesh
-            self.is_unstructured = False
+            self.is_unstructured = True
         else:
             logger.error(
                 f"Invalid grid configuration. EBFM supports the grid types {[t.name for t in GridInputType]}. "

--- a/src/ebfm/main.py
+++ b/src/ebfm/main.py
@@ -16,7 +16,6 @@ from ebfm.core import (
     LOOP_mass_balance,
 )
 from ebfm.core import LOOP_write_to_file, FINAL_create_restart_file
-from ebfm.core.grid import GridInputType
 from ebfm.core.config import CouplingConfig, GridConfig, TimeConfig
 from ebfm.core.logger import Logger, setup_logging, log_levels_map, getLogger
 from ebfm.core.cli import (
@@ -268,17 +267,11 @@ def _main_impl():
             OUT["surface_elevation"] = grid["z"]
 
         # Write output to files (only in uncoupled run and for unpartitioned grid)
-        # TODO: should be supported for all cases to avoid case distinction here
-        if not grid["is_partitioned"] and isinstance(coupler, ebfm.coupling.DummyCoupler):
-            if grid_config.grid_type is GridInputType.MATLAB:
-                io, OUTFILE = LOOP_write_to_file.main(OUTFILE, io, OUT, grid, t, time)
-            else:
-                logger.warning("Skipping writing output to file for Elmer input grids.")
-        elif grid["is_partitioned"] or not isinstance(coupler, ebfm.coupling.DummyCoupler):
-            logger.warning("Skipping writing output to file for coupled or partitioned runs.")
+        # TODO: partitioned/coupled output should be supported in a dedicated parallel-safe writer.
+        if not grid["is_partitioned"]:
+            io, OUTFILE = LOOP_write_to_file.main(OUTFILE, io, OUT, grid, t, time)
         else:
-            logger.error("Unhandled case in output writing.")
-            raise Exception("Unhandled case in output writing.")
+            logger.warning("Skipping writing output to file for partitioned runs.")
 
     # Write restart file
     # TODO: should be supported for all cases to avoid case distinction here


### PR DESCRIPTION
### Implementation:

- [x] Update `LOOP_write_to_file.py` to include separate functions for writing to structured and unstructured NetCDF files.
- [x] Update `main.py` to write to file for all non-partitioned runs (coupled or uncoupled).
- [x] Update `config/grid.py` to set all non-MATLAB meshes to 'unstructured' as they all use the same Elmer mesh. **Previously `GridInputType.ELMER` and `GridInputType.CUSTOM` were classified as 'structured' but why? Please check and revert back when needed! I lost a bit track what the different GridInputTypes were used for...** 
- [x] Update INIT.py to fix missing conversion of latitude and longitude from radians to degrees when using the Elmer mesh.

### Tests:
- [x] Test output file writing (to `Output/model_output.nc`) for regular MATLAB grid (uncoupled run with random weather):
```python
ebfm --matlab-mesh examples/dem_and_mask.mat
``` 
- [x] Test output file writing (to `Output/model_output.nc`) for unstructured Elmer grid (uncoupled run with random weather):
```python
ebfm --elmer-mesh examples/greenland_mesh_v0/MESH --netcdf-mesh examples/BedMachineGreenland-v5_lo.nc --elmer-mesh-crs-epsg 3413 --with-numba --numba-threads 4
``` 
- [ ] Test output file writing (to `Output/model_output.nc`) for unstructured Elmer grid in a coupled run with ICON forcing. 
**I would be grateful if someone else tests this. I currently work in an EBFM version without coupling features.**