### PR TITLE
Use ISO8601 as suffix for restart files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ SPDX-FileCopyrightText: 2025 EBFM Authors
 SPDX-License-Identifier: CC-BY-4.0
 -->
 
+# develop
+
+* Use ISO8601 datetime as suffic for restart files created with `--restart-dir` option. https://github.com/EBFMorg/EBFM/pull/141
+
 # v0.5.0
 
 * Add support for ISO8601 format for `--time-step`, `--time-start`, and `--time-end`. This is the recommended format and alternatives are deprecated. https://github.com/EBFMorg/EBFM/pull/137

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Once available, you can either copy or symlink the required files into the
 using the CLI arguments shown above.
 
 
-### Using `reader.py` to amend elevantion data to `examples/greenland_mesh_v0`
+### Using `reader.py` to amend elevation data to `examples/greenland_mesh_v0`
 
 The helper script `reader.py` can be used to combine an existing Elmer mesh with a DEM NetCDF file by replacing the z‑coordinates in `mesh.nodes` ahead of time. This can be useful if you want to preprocess a mesh once and reuse it for multiple EBFM runs.
 
@@ -203,6 +203,22 @@ The resulting mesh can then be used directly with EBFM similar to the example wi
 ```sh
 ebfm --elmer-mesh examples/greenland_mesh_v0_with_DEM/MESH --elmer-mesh-crs-epsg 3413
 ```
+
+### Working with restart files
+
+You may use restart files with EBFM. To create a restart file at the end of a run, please provide a `--restart-dir`:
+
+```sh
+ebfm --matlab-mesh examples/dem_and_mask.mat --restart-dir examples/restart
+```
+
+You can now use the `--restart-init` option to tell EBFM to use the restart file `examples/restart/restart_1979-01-02T00:00:00.nc` that you just created as a starting point:
+
+```sh
+ebfm --matlab-mesh examples/dem_and_mask.mat --restart-dir examples/restart --restart-init --start-time 1979-01-02T00:00:00 --end-time 1979-01-03T00:00:00
+```
+
+Note that it is necessary to provide a `--start-time` consistent with the given restart file.
 
 ### Performance and Profiling Runs
 

--- a/src/ebfm/core/INIT.py
+++ b/src/ebfm/core/INIT.py
@@ -37,9 +37,7 @@ def create_restart_file_name(time: datetime) -> str:
         str: The generated restart file name.
     """
     restart_file_prefix = "restart_"
-    restart_file_time_format = "%d-%b-%YT%H:%M"
-
-    return restart_file_prefix + time.strftime(restart_file_time_format) + ".nc"
+    return restart_file_prefix + time.isoformat() + ".nc"
 
 
 def init_config(time_config: TimeConfig, grid_config, restartdir: Path, initialize_from_restart_file: bool):


### PR DESCRIPTION
This PR provides an example on how to generate and use restart files with EBFM.

More important: It changes the formatting of file names to ISO8601 formatting. This can potentially break user's code but is consistent with new developments introduced in #137.

# Author's Todos

- [x] I ran the [pre-commit hooks](https://github.com/EBFMorg/EBFM?tab=readme-ov-file#developer-notes) and fixed all issues
- [x] I added an entry under *develop* in the [CHANGELOG.md](https://github.com/EBFMorg/EBFM/blob/main/CHANGELOG.md) (may be skipped for minor changes not observable for the user)
