### PR TITLE
Clarify that NetCDF meshes provide DEM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # develop
 
+* Rename `--netcdf-mesh` to `--netcdf-dem-mesh` and `--netcdf-mesh-unstructured` to `--netcdf-dem-mesh-unstructured`. https://github.com/EBFMorg/EBFM/pull/142
 * Use ISO8601 datetime as suffic for restart files created with `--restart-dir` option. https://github.com/EBFMorg/EBFM/pull/141
 
 # v0.5.0

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ ebfm --matlab-mesh examples/dem_and_mask.mat
 
 ### Mesh data
 
-The arguments `--matlab-mesh`, `--elmer-mesh`, and `--netcdf-mesh` allow to provide different kinds of mesh data.
+The arguments `--matlab-mesh` and `--elmer-mesh` allow to provide different kinds of mesh data.
+The arguments `--netcdf-dem-mesh` and `--netcdf-dem-mesh-unstructured` allow to add a Digital Elevation Model (DEM) for meshes that come without elevation information.
 EBFM supports the following formats:
 
 For Elmer-based inputs, the argument `--elmer-mesh-crs-epsg` is needed to define the coordinate reference system (CRS)
@@ -115,12 +116,12 @@ Important: For some larger files we are using Git LFS. Please make sure to [inst
 * Elmer Mesh with Elevation data from NetCDF: The Elmer mesh file provides x-y
   coordinate. An additioal NetCDF file is given to provide elevation data for
   these x-y coordinates. Please use the arguments `--elmer-mesh /path/to/your/elmer/mesh`
-  and `--netcdf-mesh /path/to/your/elevation.nc`
+  and `--netcdf-dem-mesh /path/to/your/elevation.nc`
 
   Usage example:
 
   ```sh
-  ebfm --elmer-mesh examples/greenland_mesh_v0/MESH --netcdf-mesh examples/BedMachineGreenland-v5_lo.nc --elmer-mesh-crs-epsg 3413
+  ebfm --elmer-mesh examples/greenland_mesh_v0/MESH --netcdf-dem-mesh examples/BedMachineGreenland-v5_lo.nc --elmer-mesh-crs-epsg 3413
   ```
 
 Note that an Elmer mesh must be provided in a directory following the structure:
@@ -158,7 +159,7 @@ path/to/your/elmer/mesh
 Usage example for partitioned mesh:
 
 ```sh
-ebfm --elmer-mesh examples/greenland_mesh_v0/MESH/partitioning.128/ --netcdf-mesh examples/BedMachineGreenland-v5_lo.nc --is-partitioned-elmer-mesh --use-part 42
+ebfm --elmer-mesh examples/greenland_mesh_v0/MESH/partitioning.128/ --netcdf-dem-mesh examples/BedMachineGreenland-v5_lo.nc --is-partitioned-elmer-mesh --use-part 42
 ```
 
 Note: The partitioned mesh is not included in this repository.
@@ -232,7 +233,7 @@ pip install -e .[performance]
 
 This additionally installs `numba` to run with multiple CPU-threads.
 
-#### Running EBFM with performance optimiuations
+#### Running EBFM with performance optimizations
 
 EBFM now includes several performance improvements and supports several options for performance testing and benchmarking:
 
@@ -316,7 +317,7 @@ Follow the install instructions from above and run the example command for a cou
 ```sh
 mpirun -np 1 ebfm \
   --elmer-mesh $MESHES/greenland_mesh_v0/MESH/partitioning.128/ \
-  --netcdf-mesh $DATA/BedMachineGreenland-v5.nc \
+  --netcdf-dem-mesh $DATA/BedMachineGreenland-v5.nc \
   --is-partitioned-elmer-mesh --use-part 1 \
   --coupler-config $CPL_CONFIG --couple-to-elmer --couple-to-icon \
   : \

--- a/src/ebfm/core/INIT.py
+++ b/src/ebfm/core/INIT.py
@@ -217,11 +217,11 @@ def init_grid(grid: GridDict, io, config: GridConfig):
     grid["has_shading"] = config.use_shading
 
     # Read grid from Elmer, elevations from BedMachine
-    if config.dem_file:
+    if config.dem_file and (config.mesh_file != config.dem_file):
         grid_input_type_supporting_dem = [GridInputType.CUSTOM, GridInputType.ELMERXIOS]
         assert (
             config.grid_type in grid_input_type_supporting_dem
-        ), f"DEM file can only be specified for {grid_input_type_supporting_dem}."
+        ), f"Additional DEM file can only be specified for {grid_input_type_supporting_dem}."
         if config.is_partitioned:
             mesh: Mesh = read_elmer_mesh(
                 mesh_root=config.mesh_file,

--- a/src/ebfm/core/cli.py
+++ b/src/ebfm/core/cli.py
@@ -162,7 +162,7 @@ def parse_cli_args(args: list[str] | None = None) -> Namespace:
         grid_type: f"--{arg_dest.replace('_', '-')}" for grid_type, arg_dest in GridConfig.mesh_arg_dests.items()
     }
     partitioned_elmer_mesh_opt = "--is-partitioned-elmer-mesh"
-    netcdf_mesh_opt = "--netcdf-mesh"
+    netcdf_dem_mesh_opt = "--netcdf-dem-mesh"
 
     parser.add_argument(
         "--version",
@@ -187,18 +187,18 @@ def parse_cli_args(args: list[str] | None = None) -> Namespace:
     )
 
     input_group.add_argument(
-        netcdf_mesh_opt,
+        netcdf_dem_mesh_opt,
         type=Path,
         help="Path to the NetCDF mesh file. Optional if using --elmer-mesh. "
-        "If --netcdf-mesh is provided elevations will be read from the given NetCDF mesh file.",
+        "If --netcdf-dem-mesh is provided elevations will be read from the given NetCDF mesh file.",
     )
 
     input_group.add_argument(
-        "--netcdf-mesh-unstructured",
+        "--netcdf-dem-mesh-unstructured",
         type=Path,
         help="Path to the unstructured NetCDF mesh file. "
         f"Optional if using {mesh_opts[GridInputType.ELMER]}. "
-        f"If --netcdf-mesh is provided elevations will be read from the given NetCDF mesh file.",
+        f"If --netcdf-dem-mesh is provided elevations will be read from the given NetCDF mesh file.",
     )
 
     grid_types_without_shading = set(GridConfig.mesh_arg_dests.keys()) - GridConfig.grid_types_supporting_shading
@@ -385,8 +385,8 @@ def parse_cli_args(args: list[str] | None = None) -> Namespace:
     if args.is_partitioned_elmer_mesh and getattr(args, GridConfig.mesh_arg_dests[GridInputType.ELMER], None) is None:
         parser.error(f"{partitioned_elmer_mesh_opt} requires {mesh_opts[GridInputType.ELMER]}")
 
-    if args.is_partitioned_elmer_mesh and args.netcdf_mesh is None:
-        parser.error(f"{partitioned_elmer_mesh_opt} requires {netcdf_mesh_opt}")
+    if args.is_partitioned_elmer_mesh and args.netcdf_dem_mesh is None:
+        parser.error(f"{partitioned_elmer_mesh_opt} requires {netcdf_dem_mesh_opt}")
 
     if args.elmer_mesh and args.elmer_mesh_crs_epsg is None:
         parser.error("--elmer-mesh-crs-epsg is required when using --elmer-mesh")

--- a/src/ebfm/core/config/grid.py
+++ b/src/ebfm/core/config/grid.py
@@ -68,7 +68,9 @@ class GridConfig:
         ), "Internal error: partitioned grid configuration requires an Elmer mesh input."
 
         if self.is_partitioned:
-            assert args.netcdf_mesh, "Internal error: partitioned grid configuration requires NetCDF mesh input."
+            assert (
+                args.netcdf_dem_mesh
+            ), "Internal error: partitioned grid configuration requires NetCDF DEM mesh input."
             logger.info("Using partitioned grid...")
             self.partition_id = args.use_part
             logger.info(f"{self.partition_id=}")
@@ -79,15 +81,15 @@ class GridConfig:
             self.grid_type = GridInputType.MATLAB
             self.mesh_file = matlab_mesh
             self.is_unstructured = False
-        elif args.netcdf_mesh and elmer_mesh:
+        elif args.netcdf_dem_mesh and elmer_mesh:
             self.grid_type = GridInputType.CUSTOM
             self.mesh_file = elmer_mesh
-            self.dem_file = args.netcdf_mesh
+            self.dem_file = args.netcdf_dem_mesh
             self.is_unstructured = False
-        elif args.netcdf_mesh_unstructured and elmer_mesh:
+        elif args.netcdf_dem_mesh_unstructured and elmer_mesh:
             self.grid_type = GridInputType.ELMERXIOS
             self.mesh_file = elmer_mesh
-            self.dem_file = args.netcdf_mesh_unstructured
+            self.dem_file = args.netcdf_dem_mesh_unstructured
             self.is_unstructured = True
         elif elmer_mesh:
             self.grid_type = GridInputType.ELMER

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -75,33 +75,33 @@ class TestElmerMeshConstraints(unittest.TestCase):
 
 
 class TestPartitionedMeshConstraints(unittest.TestCase):
-    """--is-partitioned-elmer-mesh requires both --elmer-mesh and --netcdf-mesh."""
+    """--is-partitioned-elmer-mesh requires both --elmer-mesh and --netcdf-dem-mesh."""
 
     def test_partitioned_without_elmer_mesh_rejected(self):
         with self.assertRaises(SystemExit) as ctx:
             parse_cli_args(_MATLAB + ["--is-partitioned-elmer-mesh"])
         self.assertEqual(ctx.exception.code, 2)
 
-    def test_partitioned_without_netcdf_mesh_rejected(self):
+    def test_partitioned_without_netcdf_dem_mesh_rejected(self):
         with self.assertRaises(SystemExit) as ctx:
             parse_cli_args(["--elmer-mesh", "mesh/", "--elmer-mesh-crs-epsg", "3413", "--is-partitioned-elmer-mesh"])
         self.assertEqual(ctx.exception.code, 2)
 
     @unittest.skipUnless(mpi_available, "requires MPI (pip install 'ebfm[mpi]')")
-    def test_partitioned_with_elmer_and_netcdf_accepted(self):
+    def test_partitioned_with_elmer_and_netcdf_dem_accepted(self):
         args = parse_cli_args(
             [
                 "--elmer-mesh",
                 "mesh/",
                 "--elmer-mesh-crs-epsg",
                 "3413",
-                "--netcdf-mesh",
+                "--netcdf-dem-mesh",
                 "mesh.nc",
                 "--is-partitioned-elmer-mesh",
             ]
         )
         self.assertTrue(args.is_partitioned_elmer_mesh)
-        self.assertEqual(args.netcdf_mesh, Path("mesh.nc"))
+        self.assertEqual(args.netcdf_dem_mesh, Path("mesh.nc"))
 
 
 class TestDefaults(unittest.TestCase):
@@ -143,8 +143,8 @@ class TestDefaults(unittest.TestCase):
         self.assertFalse(self.args.couple_to_elmer_ice)
         self.assertFalse(self.args.couple_to_icon_atmo)
 
-    def test_netcdf_mesh_default_none(self):
-        self.assertIsNone(self.args.netcdf_mesh)
+    def test_netcdf_dem_mesh_default_none(self):
+        self.assertIsNone(self.args.netcdf_dem_mesh)
 
     def test_random_seed_default_none(self):
         self.assertIsNone(self.args.random_seed)


### PR DESCRIPTION
* Rename --netcdf-mesh to --netcdf-dem-mesh
* Rename --netcdf-mesh-unstructured to --netcdf-dem-mesh-unstructured.

# Motivation

* Allows better differentiation between NetCDF data (with dem+mesh info) added in #128 and pure DEM NetCDF data

# Author's Todos

- [x] I ran the [pre-commit hooks](https://github.com/EBFMorg/EBFM?tab=readme-ov-file#developer-notes) and fixed all issues
- [x] I added an entry under *develop* in the [CHANGELOG.md](https://github.com/EBFMorg/EBFM/blob/main/CHANGELOG.md) (may be skipped for minor changes not observable for the user)
