### PR TITLE
Discontinue Python 3.10 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v6
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # develop
 
+* Remove support for Python 3.10. https://github.com/EBFMorg/EBFM/pull/143
 * Assure model time is always in UTC+0, allowing removal of the previously hard-coded (time-zone dependent) parameter dT_UTC. https://github.com/EBFMorg/EBFM/pull/138
 * Rename `--netcdf-mesh` to `--netcdf-dem-mesh` and `--netcdf-mesh-unstructured` to `--netcdf-dem-mesh-unstructured`. https://github.com/EBFMorg/EBFM/pull/142
 * Use ISO8601 datetime as suffix for restart files created with `--restart-dir` option. https://github.com/EBFMorg/EBFM/pull/141

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = [ "version" ]
 authors = [ {name="EBFM Authors"} ]
 license = "BSD-3-Clause"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "mypy >= 1.0",
     "netCDF4 >= 1.7",

--- a/tests/core/config/test_time.py
+++ b/tests/core/config/test_time.py
@@ -17,10 +17,8 @@ class TestTimeConfig(unittest.TestCase):
 
     def test_init(self):
         args = Namespace(
-            start_time="2024-01-01T00:00:00+00:00",
-            # start_time="2024-01-01T00:00:00Z",  # only for Python 3.11 and later, not Python 3.10
-            end_time="2024-01-02T00:00:00+00:00",
-            # start_time="2024-01-02T00:00:00Z",  # only for Python 3.11 and later, not Python 3.10
+            start_time="2024-01-01T00:00:00Z",
+            end_time="2024-01-02T00:00:00Z",
             time_step="PT1H",
             calendar="proleptic_gregorian",
         )

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 
 [tox]
 min_version = 4.0
-envlist = py{310,311,312,313}
+envlist = py{311,312,313,314}
 
 [testenv]
 extras =
@@ -59,7 +59,8 @@ commands =
 
 [gh-actions]
 python =
-    3.10: py310 # Python Version used on Levante
     3.11: py311
     3.12: py312 # Development version used on Ubuntu 24.04
     3.13: py313 # Development version used on Ubuntu 25.04
+    3.14: py310 # Python Version used on Levante (spack load miniforge3@26.3.2-3%gcc@13.4.0/fg4pr4)
+


### PR DESCRIPTION
Python 3.10 is reaching its [EOL in October 2026](https://devguide.python.org/versions/) and comes with some restrictions.

This PR updates the corresponding tests (drop 3.10 and test 3.14) and performs corresponding cleanup.

# Author's Todos

- [x] I ran the [pre-commit hooks](https://github.com/EBFMorg/EBFM?tab=readme-ov-file#developer-notes) and fixed all issues
- [x] I added an entry under *develop* in the [CHANGELOG.md](https://github.com/EBFMorg/EBFM/blob/main/CHANGELOG.md) (may be skipped for minor changes not observable for the user)
