### PR TITLE
Check `get_field_timestep` for `None`

### DIFF
--- a/src/ebfm/coupling/fields/yacField.py
+++ b/src/ebfm/coupling/fields/yacField.py
@@ -220,6 +220,8 @@ class YACField:
         ), f"Field '{self.name}' has invalid YAC exchange type '{field_role}'. Must be SOURCE."
 
         src_field_timestep = yac_interface.get_field_timestep(src_comp, src_grid, src_field)
+        if not src_field_timestep:  # returns None if not set
+            src_field_timestep = "N/A"
 
         src_field_metadata = yac_interface.get_field_metadata(src_comp, src_grid, src_field)
         if not src_field_metadata:  # metadata is optional, returns None if not set


### PR DESCRIPTION
Note: Added a guard in YAC via https://gitlab.dkrz.de/YAC/YAC-dev/-/commit/994af617020834736ea927ffdff63bc24107745b. Currently, a missing timestep leads to a segfault but this should be fixed in the next release and adding the guard here already now does not harm.

# Author's Todos

- [x] I ran the [pre-commit hooks](https://github.com/EBFMorg/EBFM?tab=readme-ov-file#developer-notes) and fixed all issues
