### PR TITLE
Explicitly check for Action.NO_DATA_RECEIVED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ SPDX-FileCopyrightText: 2025 EBFM Authors
 SPDX-License-Identifier: CC-BY-4.0
 -->
 
+# v0.6.1
+
+* Catch invalid values returned by YAC's get and forward info to user. https://github.com/EBFMorg/EBFM/pull/145.
+
 # v0.6.0
 
 * Rename "h" received from Elmer to "surface_elevation". https://github.com/EBFMorg/EBFM/pull/124.

--- a/src/ebfm/coupling/components/base.py
+++ b/src/ebfm/coupling/components/base.py
@@ -8,7 +8,6 @@ from collections.abc import Mapping, Callable
 import numpy as np
 
 from ebfm.core import logging
-from ebfm.coupling.couplers.base import CouplerExitCode
 
 logger = logging.getLogger(__name__)
 
@@ -102,16 +101,7 @@ class Component(ABC):
         data, err = self._coupler.get(self.name, field_name)
 
         if err:
-            if err is CouplerExitCode.NO_DATA_RECEIVED:
-                logger.debug(
-                    f"Get for {field_name=} returned exit code ({err=}). "
-                    "No data was received from the other component."
-                )
-            else:
-                logger.warning(
-                    f"Get for {field_name=} returned unexpected exit code ({err=}). "
-                    "Please report this to the developers."
-                )
+            logger.warning(f"Get for {field_name=} returned exit code ({err=}).")
             return None
 
         assert data is not None, f"Received data for field '{field_name}' is None. {err}"

--- a/src/ebfm/coupling/components/base.py
+++ b/src/ebfm/coupling/components/base.py
@@ -12,7 +12,7 @@ from ebfm.core import logging
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from ebfm.coupling.couplers.base import Coupler
+    from ebfm.coupling.couplers.base import Coupler, CouplerExitCode
     from ebfm.coupling.fields.base import FieldSet
 
 
@@ -79,7 +79,8 @@ class Component(ABC):
             err = self._coupler.put(self.name, field_name, transform(data_to_exchange[field_name]))
             if err:
                 logger.warning(
-                    f"Put for {field_name=} returned error code ({err=}). Please report this to the developers."
+                    f"Put for {field_name=} returned unexpected exit code ({err=}). "
+                    "Please report this to the developers."
                 )
 
     def _get_if_coupled(self, field_name: str, transform: Callable = identity) -> np.ndarray | None:
@@ -96,9 +97,16 @@ class Component(ABC):
             data, err = self._coupler.get(self.name, field_name)
             logger.debug(f"Received data for field '{field_name}' from coupler: {data}")
             if err:
-                logger.warning(
-                    f"Get for {field_name=} returned error code ({err=}). Please report this to the developers."
-                )
+                if err is CouplerExitCode.NO_DATA_RECEIVED:
+                    logger.debug(
+                        f"Get for {field_name=} returned exit code ({err=}). "
+                        "No data was received from the other component."
+                    )
+                else:
+                    logger.warning(
+                        f"Get for {field_name=} returned unexpected exit code ({err=}). "
+                        "Please report this to the developers."
+                    )
             assert data is not None, f"Received data for field '{field_name}' is None. {err}"
             return transform(data)
         return None

--- a/src/ebfm/coupling/components/base.py
+++ b/src/ebfm/coupling/components/base.py
@@ -8,11 +8,13 @@ from collections.abc import Mapping, Callable
 import numpy as np
 
 from ebfm.core import logging
+from ebfm.coupling.couplers.base import CouplerExitCode
 
 logger = logging.getLogger(__name__)
 
+
 if TYPE_CHECKING:
-    from ebfm.coupling.couplers.base import Coupler, CouplerExitCode
+    from ebfm.coupling.couplers.base import Coupler
     from ebfm.coupling.fields.base import FieldSet
 
 

--- a/src/ebfm/coupling/components/base.py
+++ b/src/ebfm/coupling/components/base.py
@@ -93,23 +93,28 @@ class Component(ABC):
         """
         from ebfm.coupling.fields.base import ExchangeType
 
-        if self._coupler.has_field(self.name, field_name, ExchangeType.TARGET):
-            data, err = self._coupler.get(self.name, field_name)
-            logger.debug(f"Received data for field '{field_name}' from coupler: {data}")
-            if err:
-                if err is CouplerExitCode.NO_DATA_RECEIVED:
-                    logger.debug(
-                        f"Get for {field_name=} returned exit code ({err=}). "
-                        "No data was received from the other component."
-                    )
-                else:
-                    logger.warning(
-                        f"Get for {field_name=} returned unexpected exit code ({err=}). "
-                        "Please report this to the developers."
-                    )
-            assert data is not None, f"Received data for field '{field_name}' is None. {err}"
-            return transform(data)
-        return None
+        if not self._coupler.has_field(self.name, field_name, ExchangeType.TARGET):
+            logger.debug(f"Field '{field_name}' is not coupled for component '{self.name}', skipping get.")
+            return None
+
+        data, err = self._coupler.get(self.name, field_name)
+
+        if err:
+            if err is CouplerExitCode.NO_DATA_RECEIVED:
+                logger.debug(
+                    f"Get for {field_name=} returned exit code ({err=}). "
+                    "No data was received from the other component."
+                )
+            else:
+                logger.warning(
+                    f"Get for {field_name=} returned unexpected exit code ({err=}). "
+                    "Please report this to the developers."
+                )
+            return None
+
+        assert data is not None, f"Received data for field '{field_name}' is None. {err}"
+        logger.debug(f"Received data for field '{field_name}' from coupler: {data}")
+        return transform(data)
 
     @abstractmethod
     def exchange(self, data_to_exchange: Mapping[str, np.ndarray]) -> dict[str, np.ndarray]:

--- a/src/ebfm/coupling/couplers/base.py
+++ b/src/ebfm/coupling/couplers/base.py
@@ -31,11 +31,13 @@ Examples:
 """
 
 
-class CouplerErrorCode(Enum):
+class CouplerExitCode(Enum):
     """
-    Error codes returned by Coupler.get() and Coupler.put().
+    Exit codes returned by Coupler.get() and Coupler.put().
 
-    A value of None (i.e. no error code) indicates success.
+    Depending on the exit code this can mean a fatal error or that special handling in the user code is necessary.
+
+    A value of None (i.e. no exit code) always indicates success.
     """
 
     WRONG_EXCHANGE_TYPE = "wrong_exchange_type"
@@ -43,6 +45,9 @@ class CouplerErrorCode(Enum):
 
     WRONG_ROLE = "wrong_role"
     """The field's actual role in the coupler config does not match its declared role."""
+
+    NO_DATA_RECEIVED = "no_data_received"
+    """No data was received from the other component at this point in time."""
 
 
 class Coupler(ABC, Generic[CouplerExchangeType]):
@@ -170,7 +175,7 @@ class Coupler(ABC, Generic[CouplerExchangeType]):
         raise NotImplementedError("_map_exchange_type must be implemented in subclasses.")
 
     @abstractmethod
-    def put(self, component_name: str, field_name: str, data: np.ndarray) -> CouplerErrorCode | None:
+    def put(self, component_name: str, field_name: str, data: np.ndarray) -> CouplerExitCode | None:
         """
         Put data to another component
 
@@ -178,19 +183,19 @@ class Coupler(ABC, Generic[CouplerExchangeType]):
         @param[in] field_name name of the field to put data to
         @param[in] data data to be sent
 
-        @returns error code, or None if no error occurred.
+        @returns exit code, or None if put successfully completed.
         """
         raise NotImplementedError("put method must be implemented in subclasses.")
 
     @abstractmethod
-    def get(self, component_name: str, field_name: str) -> tuple[np.ndarray | None, CouplerErrorCode | None]:
+    def get(self, component_name: str, field_name: str) -> tuple[np.ndarray | None, CouplerExitCode | None]:
         """
         Get data from another component
 
         @param[in] component_name name of the component to get data from
         @param[in] field_name name of the field to get data for
 
-        @returns tuple of (field data, error code). Error code is None if no error occurred.
+        @returns tuple of (field data, exit code). Exit code is None if get successfully received data.
         """
         raise NotImplementedError("get method must be implemented in subclasses.")
 

--- a/src/ebfm/coupling/couplers/dummyCoupler.py
+++ b/src/ebfm/coupling/couplers/dummyCoupler.py
@@ -5,7 +5,7 @@
 import numpy as np
 
 from . import Coupler
-from .base import GridDict, CouplingConfig, CouplerErrorCode
+from .base import GridDict, CouplingConfig, CouplerExitCode
 from ebfm.coupling.fields import GenericExchangeType, FieldSet
 
 import logging
@@ -45,7 +45,7 @@ class DummyCoupler(Coupler):
         """
         return exchange_type
 
-    def put(self, component_name: str, field_name: str, data: np.ndarray) -> CouplerErrorCode | None:
+    def put(self, component_name: str, field_name: str, data: np.ndarray) -> CouplerExitCode | None:
         """
         Put data to another component
 
@@ -53,20 +53,20 @@ class DummyCoupler(Coupler):
         @param[in] field_name name of the field to put data to
         @param[in] data data to be sent
 
-        @returns error code, or None if no error occurred.
+        @returns exit code, or None if put successfully completed.
         """
         logger.debug(f"Put field {field_name} to {component_name}...")
         logger.debug("Do nothing for DummyCoupler.")
         return None
 
-    def get(self, component_name: str, field_name: str) -> tuple[np.ndarray | None, CouplerErrorCode | None]:
+    def get(self, component_name: str, field_name: str) -> tuple[np.ndarray | None, CouplerExitCode | None]:
         """
         Get data from another component
 
         @param[in] component_name name of the component to get data from
         @param[in] field_name name of the field to get data for
 
-        @returns tuple of (field data, error code). Error code is None if no error occurred.
+        @returns tuple of (field data, exit code). Exit code is None if get successfully received data.
         """
         logger.debug(f"Get field {field_name} from {component_name}...")
         logger.debug("Do nothing for DummyCoupler.")

--- a/src/ebfm/coupling/couplers/fakeCoupler.py
+++ b/src/ebfm/coupling/couplers/fakeCoupler.py
@@ -10,7 +10,7 @@ import numpy as np
 from ebfm.core import logging
 from ebfm.core.config import CouplingConfig
 
-from .base import Coupler, CouplerErrorCode, Grid, GridDict
+from .base import Coupler, CouplerExitCode, Grid, GridDict
 from ebfm.coupling.fields import FieldSet, GenericExchangeType
 
 logger = logging.getLogger(__name__)
@@ -185,7 +185,7 @@ class FakeCoupler(Coupler):
         for field in field_definitions:
             self.fields.add(field)
 
-    def put(self, component_name: str, field_name: str, data: np.ndarray) -> CouplerErrorCode | None:
+    def put(self, component_name: str, field_name: str, data: np.ndarray) -> CouplerExitCode | None:
         """
         Log and discard outgoing data – no actual transfer is performed.
 
@@ -193,12 +193,12 @@ class FakeCoupler(Coupler):
         @param[in] field_name name of the field to put data to
         @param[in] data data that would be sent to the coupled model
 
-        @returns None (no error)
+        @returns exit code, or None if put successfully completed.
         """
         logger.debug(f"FakeCoupler put: field '{field_name}' -> '{component_name}' (discarded).")
         return None
 
-    def get(self, component_name: str, field_name: str) -> tuple[np.ndarray | None, CouplerErrorCode | None]:
+    def get(self, component_name: str, field_name: str) -> tuple[np.ndarray | None, CouplerExitCode | None]:
         """
         Return a fake array for the requested field.
 
@@ -209,7 +209,7 @@ class FakeCoupler(Coupler):
         @param[in] component_name name of the component to get data from
         @param[in] field_name name of the field to retrieve
 
-        @returns tuple of (fake field data, error code). Error code is always None.
+        @returns tuple of (fake field data, exit code). Exit code is None if get successfully received data.
         """
         key = (component_name, field_name)
         fill_value = self._fake_values.get(key, 0.0)

--- a/src/ebfm/coupling/couplers/yacCoupler.py
+++ b/src/ebfm/coupling/couplers/yacCoupler.py
@@ -262,7 +262,7 @@ class YACCoupler(Coupler[yac.ExchangeType]):
             logger.debug(f"No data for field {field.name} from {field.coupled_component.name} received.")
             return None, CouplerExitCode.NO_DATA_RECEIVED
 
-        expected_actions = {yac.Action.GET, yac.Action.GET_FOR_RESTART}
+        expected_actions = {yac.Action.COUPLING, yac.Action.GET_FOR_RESTART}
 
         assert action in expected_actions, (
             f"Expected action {expected_actions} for field '{field.name}' from component "

--- a/src/ebfm/coupling/couplers/yacCoupler.py
+++ b/src/ebfm/coupling/couplers/yacCoupler.py
@@ -252,6 +252,16 @@ class YACCoupler(Coupler[yac.ExchangeType]):
             logger.debug(f"No data for field {field.name} from {field.coupled_component.name} received.")
             return None, CouplerExitCode.NO_DATA_RECEIVED
 
+        if action is yac.Action.OUT_OF_BOUNDS:
+            logger.warning(
+                f"Received YAC action OUT_OF_BOUNDS for field {field.name} " "from {field.coupled_component.name}."
+            )
+            logger.warning(f"Skipping get and updating field {field.name} to next time step.")
+            field.field_handle.update()
+            logger.warning("Please review your coupling configuration for errors.")
+            logger.debug(f"No data for field {field.name} from {field.coupled_component.name} received.")
+            return None, CouplerExitCode.NO_DATA_RECEIVED
+
         expected_actions = {yac.Action.GET, yac.Action.GET_FOR_RESTART}
 
         assert action in expected_actions, (
@@ -265,6 +275,7 @@ class YACCoupler(Coupler[yac.ExchangeType]):
             f"Expected data shape ({_COLLECTION_SIZE}, ...), got {data.shape} for field '{field.name}' "
             f"from component '{field.coupled_component.name}'."
         )
+
         return data[_COLLECTION_SIZE - 1], error
 
     def _handle_field_validation_error(self, error_msg: str):

--- a/src/ebfm/coupling/couplers/yacCoupler.py
+++ b/src/ebfm/coupling/couplers/yacCoupler.py
@@ -252,7 +252,7 @@ class YACCoupler(Coupler[yac.ExchangeType]):
             logger.debug(f"No data for field {field.name} from {field.coupled_component.name} received.")
             return None, CouplerExitCode.NO_DATA_RECEIVED
 
-        if action is yac.Action.OUT_OF_BOUNDS:
+        if action is yac.Action.OUT_OF_BOUND:
             logger.warning(
                 f"Received YAC action OUT_OF_BOUNDS for field {field.name} " "from {field.coupled_component.name}."
             )

--- a/src/ebfm/coupling/couplers/yacCoupler.py
+++ b/src/ebfm/coupling/couplers/yacCoupler.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from ebfm.core import logging
 
-from .base import Coupler, Grid, GridDict, CouplingConfig, CouplerErrorCode
+from .base import Coupler, Grid, GridDict, CouplingConfig, CouplerExitCode
 
 # from coupling import Field  # TODO: rather use generic Field from coupling
 from ebfm.coupling.fields import FieldSet, Field, GenericExchangeType
@@ -174,7 +174,7 @@ class YACCoupler(Coupler[yac.ExchangeType]):
         assert isinstance(field, YACField), f"Expected YACField, got {type(field)}"
         return field
 
-    def put(self, component_name: str, field_name: str, data: np.ndarray) -> CouplerErrorCode | None:
+    def put(self, component_name: str, field_name: str, data: np.ndarray) -> CouplerExitCode | None:
         """
         Put data to another component
 
@@ -182,7 +182,7 @@ class YACCoupler(Coupler[yac.ExchangeType]):
         @param[in] field_name name of the field to put data to
         @param[in] data data to be sent
 
-        @returns error code, or None if no error occurred.
+        @returns exit code, or None if put successfully completed.
         """
 
         field = self._get_field(component_name, field_name)
@@ -194,7 +194,7 @@ class YACCoupler(Coupler[yac.ExchangeType]):
                 f"Field has to be a SOURCE field, but {field.exchange_type=}."
             )
             self._handle_field_validation_error(error_msg)
-            return CouplerErrorCode.WRONG_EXCHANGE_TYPE  # If we didn't raise, skip the put operation
+            return CouplerExitCode.WRONG_EXCHANGE_TYPE  # If we didn't raise, skip the put operation
 
         logger.debug(f"Sending field {field.name} to {field.coupled_component.name}...")
         assert field.field_handle is not None, f"YAC field for '{field.name}' has not been created yet."
@@ -202,17 +202,14 @@ class YACCoupler(Coupler[yac.ExchangeType]):
         logger.debug(f"Sending field {field.name} to {field.coupled_component.name} complete.")
         return None
 
-    def get(self, component_name: str, field_name: str) -> tuple[np.ndarray | None, CouplerErrorCode | None]:
+    def get(self, component_name: str, field_name: str) -> tuple[np.ndarray | None, CouplerExitCode | None]:
         """
         Get data from another component
 
         @param[in] component_name name of the component to get data from
         @param[in] field_name name of the field to get data for
 
-        @returns tuple of (field data, error code). Error code is None if no error occurred.
-                 Field data is always the value returned by YAC (e.g. zeros as fallback) even
-                 when an error code is set, so the caller can decide whether to use it or substitute
-                 their own fallback.
+        @returns tuple of (field data, exit code). Exit code is None if get successfully received data.
         """
 
         field = self._get_field(component_name, field_name)
@@ -226,7 +223,7 @@ class YACCoupler(Coupler[yac.ExchangeType]):
                 f"Field has to be a TARGET field, but its {field.exchange_type=}."
             )
             self._handle_field_validation_error(error_msg)
-            return None, CouplerErrorCode.WRONG_EXCHANGE_TYPE
+            return None, CouplerExitCode.WRONG_EXCHANGE_TYPE
 
         # Also check the actual YAC role: a field absent from the coupling YAML has role NONE
         # and yac_field.get() would silently return zeros -- signal this via error code so the
@@ -243,9 +240,25 @@ class YACCoupler(Coupler[yac.ExchangeType]):
                 f"is '{role}' (field not present in coupling config)."
             )
             self._handle_field_validation_error(error_msg)
-            error = CouplerErrorCode.WRONG_ROLE
+            error = CouplerExitCode.WRONG_ROLE
 
         logger.debug(f"Receiving field {field.name} from {field.coupled_component.name}...")
+        action = field.field_handle.action()
+
+        if action is yac.Action.NONE:
+            logger.debug(f"Received YAC action NONE for field {field.name} from {field.coupled_component.name}.")
+            logger.debug(f"Skipping get and updating field {field.name} to next time step.")
+            field.field_handle.update()
+            logger.debug(f"No data for field {field.name} from {field.coupled_component.name} received.")
+            return None, CouplerExitCode.NO_DATA_RECEIVED
+
+        expected_actions = {yac.Action.GET, yac.Action.GET_FOR_RESTART}
+
+        assert action in expected_actions, (
+            f"Expected action {expected_actions} for field '{field.name}' from component "
+            f"'{field.coupled_component.name}', but got {action}."
+        )
+
         data, action = field.field_handle.get()
         logger.debug(f"Receiving field {field.name} from {field.coupled_component.name} complete.")
         assert data.shape[0] == _COLLECTION_SIZE, (

--- a/src/ebfm/coupling/couplers/yacCoupler.py
+++ b/src/ebfm/coupling/couplers/yacCoupler.py
@@ -243,7 +243,7 @@ class YACCoupler(Coupler[yac.ExchangeType]):
             error = CouplerExitCode.WRONG_ROLE
 
         logger.debug(f"Receiving field {field.name} from {field.coupled_component.name}...")
-        action = field.field_handle.action()
+        action = field.field_handle.action
 
         if action is yac.Action.NONE:
             logger.debug(f"Received YAC action NONE for field {field.name} from {field.coupled_component.name}.")


### PR DESCRIPTION
* Changed `CouplerErrorCode` to `CouplerExitCode` (not always error/fatal)
* Introduced check for action `NO_DATA_RECEIVED` to avoid getting and forwarding garbage values to user. Call `update` instead of `get` in this case.
* Improve logging.

# Author's Todos

- [x] I ran the [pre-commit hooks](https://github.com/EBFMorg/EBFM?tab=readme-ov-file#developer-notes) and fixed all issues
- [x] I added an entry under *develop* in the [CHANGELOG.md](https://github.com/EBFMorg/EBFM/blob/main/CHANGELOG.md) (may be skipped for minor changes not observable for the user)
