### PR TITLE
Further CPU (host-side) performance optimization (in LOOP_SNOW.py)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # develop
 
-* Optimize host-side code in `LOOP_SNOW`: fewer full-grid copies and the heat conduction precompute moved into a Numba kernel. Results are unchanged; with `--with-numba` the total runtime drops by ~30% for large meshes. https://github.com/EBFMorg/EBFM/pull/XXX.
-* The `performance` extra no longer installs `mpi4py`: Numba parallelises with threads inside a single process and does not require MPI. Use `EBFM[performance,mpi]` to combine both. https://github.com/EBFMorg/EBFM/pull/XXX.
+* Further optimizations in CPU/host-side code in `LOOP_SNOW.py`: fewer full-grid copies, heat conduction precompute moved into Numba kernel. https://github.com/EBFMorg/EBFM/pull/147.
+* The `performance` extra no longer installs `mpi4py`: Numba parallelises with threads inside a single process and does not require MPI. Use `EBFM[performance,mpi]` to combine both. https://github.com/EBFMorg/EBFM/pull/147.
 * Fixed bug where resuming from a restart file (`--restart-init`) could lead to time step sizes equal to zero in `LOOP_SNOW.py`. Loading a restart file now asserts the restart variables to contain no missing values and converts them to plain `ndarray`. https://github.com/EBFMorg/EBFM/pull/154
 * Fixed bug in icon_to_atmo.py to convert pr_snow units to mwe per timestep (rather than using kg m-2 s-1). https://github.com/EBFMorg/EBFM/pull/149
 * Add general interface for definition of fallback values if a coupled component does not provide expected data for individual fields. https://github.com/EBFMorg/EBFM/pull/146.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ SPDX-License-Identifier: CC-BY-4.0
 # develop
 
 * Optimize host-side code in `LOOP_SNOW`: fewer full-grid copies and the heat conduction precompute moved into a Numba kernel. Results are unchanged; with `--with-numba` the total runtime drops by ~30% for large meshes. https://github.com/EBFMorg/EBFM/pull/XXX.
+* The `performance` extra no longer installs `mpi4py`: Numba parallelises with threads inside a single process and does not require MPI. Use `EBFM[performance,mpi]` to combine both. https://github.com/EBFMorg/EBFM/pull/XXX.
 * Fixed bug where resuming from a restart file (`--restart-init`) could lead to time step sizes equal to zero in `LOOP_SNOW.py`. Loading a restart file now asserts the restart variables to contain no missing values and converts them to plain `ndarray`. https://github.com/EBFMorg/EBFM/pull/154
 * Fixed bug in icon_to_atmo.py to convert pr_snow units to mwe per timestep (rather than using kg m-2 s-1). https://github.com/EBFMorg/EBFM/pull/149
 * Add general interface for definition of fallback values if a coupled component does not provide expected data for individual fields. https://github.com/EBFMorg/EBFM/pull/146.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # develop
 
+* Optimize host-side code in `LOOP_SNOW`: fewer full-grid copies and the heat conduction precompute moved into a Numba kernel. Results are unchanged; with `--with-numba` the total runtime drops by ~30% for large meshes. https://github.com/EBFMorg/EBFM/pull/XXX.
 * Fixed bug where resuming from a restart file (`--restart-init`) could lead to time step sizes equal to zero in `LOOP_SNOW.py`. Loading a restart file now asserts the restart variables to contain no missing values and converts them to plain `ndarray`. https://github.com/EBFMorg/EBFM/pull/154
 * Fixed bug in icon_to_atmo.py to convert pr_snow units to mwe per timestep (rather than using kg m-2 s-1). https://github.com/EBFMorg/EBFM/pull/149
 * Add general interface for definition of fallback values if a coupled component does not provide expected data for individual fields. https://github.com/EBFMorg/EBFM/pull/146.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ cpl = [
 ]
 
 performance = [
-    "EBFM[mpi]",
     "numba >= 0.59",
 ]
 

--- a/src/ebfm/core/LOOP_SNOW.py
+++ b/src/ebfm/core/LOOP_SNOW.py
@@ -6,7 +6,12 @@ import numpy as np
 
 from .compute_backend import get_backend, ComputeBackend
 from .constants import SECONDS_PER_HOUR
-from .LOOP_SNOW_kernels import _compaction_kernel, _heat_conduction_kernel, _percolation_kernel
+from .LOOP_SNOW_kernels import (
+    _compaction_kernel,
+    _heat_conduction_kernel,
+    _heat_conduction_prep_kernel,
+    _percolation_kernel,
+)
 
 # line_profiler support: `profile` is injected as a builtin by kernprof.
 # When running normally, fall back to a no-op so the decorator stays in place.
@@ -415,40 +420,39 @@ def main(C, OUT, IN, dt, grid, phys):
         """
         Calculate heat diffusion and update temperatures
         """
-        dz1 = (OUT["subZ"][:, 0] + 0.5 * OUT["subZ"][:, 1]) ** 2
-        dz2 = 0.5 * (OUT["subZ"][:, 2:] + OUT["subZ"][:, 1:-1]) ** 2
-        kk = 0.138 - 1.01e-3 * OUT["subD"] + 3.233e-6 * OUT["subD"] ** 2  # Effective conductivity
-        c_eff = OUT["subD"] * (152.2 + 7.122 * OUT["subT"])  # Effective heat capacity
-
-        # Stability time step (CFL condition)
-        # Layer 0: surface ghost layer, excluded from CFL condition
-        dt_stab = (
-            0.5
-            * np.min(c_eff[:, 1:], axis=1)
-            * np.min(OUT["subZ"][:, 1:], axis=1) ** 2
-            / np.max(kk[:, 1:], axis=1)
-            / C["dayseconds"]
-        )
-        assert (dt_stab > 0).all(), "cells with dt_stab <= 0 are forbidden!"
-
-        # subZ and c_eff do not change
-        # Precompute kk*subZ products once
-        # kk_sz_top: conductivity-thickness product for the top interface
-        # kk_sz_interior: same for all interior interfaces
-        kk_sz_top = kk[:, 0] * OUT["subZ"][:, 0] + 0.5 * kk[:, 1] * OUT["subZ"][:, 1]
-        kk_sz_interior = kk[:, 1:-1] * OUT["subZ"][:, 1:-1] + kk[:, 2:] * OUT["subZ"][:, 2:]
-
-        # Precompute full temperature-update denominators once
-        # denom_layer1: first active layer (layer 0: surface ghost layer overwritten from Tsurf)
-        denom_layer1 = c_eff[:, 1] * (0.5 * OUT["subZ"][:, 0] + 0.5 * OUT["subZ"][:, 1] + 0.25 * OUT["subZ"][:, 2])
-        denom_interior = c_eff[:, 2:-1] * (
-            0.25 * OUT["subZ"][:, 1:-2] + 0.5 * OUT["subZ"][:, 2:-1] + 0.25 * OUT["subZ"][:, 3:]
-        )
-        denom_bottom = c_eff[:, -1] * (0.25 * OUT["subZ"][:, -2] + 0.75 * OUT["subZ"][:, -1])
-
         # ------ Heat Conduction Loop ------
         if get_backend() == ComputeBackend.NUMBA:
-            # Numba parallel path: prange(gpsum), each column solved independently.
+            # Numba parallel path: the per-column precompute that the NumPy branch
+            # below does in host NumPy is done in _heat_conduction_prep_kernel
+            # (prange over gpsum); the CFL solve then runs in _heat_conduction_kernel.
+            gpsum, nl = OUT["subT"].shape
+            kk = np.empty((gpsum, nl))
+            c_eff = np.empty((gpsum, nl))
+            kk_sz_top = np.empty(gpsum)
+            kk_sz_interior = np.empty((gpsum, nl - 2))
+            dz1 = np.empty(gpsum)
+            dz2 = np.empty((gpsum, nl - 2))
+            denom_layer1 = np.empty(gpsum)
+            denom_interior = np.empty((gpsum, nl - 3))
+            denom_bottom = np.empty(gpsum)
+            dt_stab = np.empty(gpsum)
+            _heat_conduction_prep_kernel(
+                OUT["subD"],
+                OUT["subZ"],
+                OUT["subT"],
+                kk,
+                c_eff,
+                kk_sz_top,
+                kk_sz_interior,
+                dz1,
+                dz2,
+                denom_layer1,
+                denom_interior,
+                denom_bottom,
+                dt_stab,
+                C["dayseconds"],
+            )
+            assert (dt_stab > 0).all(), "cells with dt_stab <= 0 are forbidden!"
             _heat_conduction_kernel(
                 OUT["subT"],
                 OUT["Tsurf"],
@@ -466,7 +470,36 @@ def main(C, OUT, IN, dt, grid, phys):
             )
 
         else:
-            # NumPy path: explicit while-loop with vectorized column updates.
+            # NumPy path: host precompute + explicit while-loop with vectorized
+            # column updates.
+            dz1 = (OUT["subZ"][:, 0] + 0.5 * OUT["subZ"][:, 1]) ** 2
+            dz2 = 0.5 * (OUT["subZ"][:, 2:] + OUT["subZ"][:, 1:-1]) ** 2
+            kk = 0.138 - 1.01e-3 * OUT["subD"] + 3.233e-6 * OUT["subD"] ** 2  # Effective conductivity
+            c_eff = OUT["subD"] * (152.2 + 7.122 * OUT["subT"])  # Effective heat capacity
+
+            # Stability time step (CFL condition)
+            # Layer 0: surface ghost layer, excluded from CFL condition
+            dt_stab = (
+                0.5
+                * np.min(c_eff[:, 1:], axis=1)
+                * np.min(OUT["subZ"][:, 1:], axis=1) ** 2
+                / np.max(kk[:, 1:], axis=1)
+                / C["dayseconds"]
+            )
+            assert (dt_stab > 0).all(), "cells with dt_stab <= 0 are forbidden!"
+
+            # Precompute kk*subZ products and the temperature-update denominators once.
+            # kk_sz_top: conductivity-thickness product for the top interface;
+            # kk_sz_interior: same for all interior interfaces.
+            kk_sz_top = kk[:, 0] * OUT["subZ"][:, 0] + 0.5 * kk[:, 1] * OUT["subZ"][:, 1]
+            kk_sz_interior = kk[:, 1:-1] * OUT["subZ"][:, 1:-1] + kk[:, 2:] * OUT["subZ"][:, 2:]
+            # denom_layer1: first active layer (layer 0: surface ghost layer overwritten from Tsurf)
+            denom_layer1 = c_eff[:, 1] * (0.5 * OUT["subZ"][:, 0] + 0.5 * OUT["subZ"][:, 1] + 0.25 * OUT["subZ"][:, 2])
+            denom_interior = c_eff[:, 2:-1] * (
+                0.25 * OUT["subZ"][:, 1:-2] + 0.5 * OUT["subZ"][:, 2:-1] + 0.25 * OUT["subZ"][:, 3:]
+            )
+            denom_bottom = c_eff[:, -1] * (0.25 * OUT["subZ"][:, -2] + 0.75 * OUT["subZ"][:, -1])
+
             tt = np.zeros(grid["gpsum"])
             kdTdz = np.zeros_like(OUT["subT"])
             # Ping-pong buffers:

--- a/src/ebfm/core/LOOP_SNOW.py
+++ b/src/ebfm/core/LOOP_SNOW.py
@@ -86,8 +86,7 @@ def main(C, OUT, IN, dt, grid, phys):
             shift = np.minimum(shift_tot, max_subZ)
             shift_tot -= shift
 
-            # The no-shift branch only touches the top layer, so snapshot just
-            # column 0 (cheap (gpsum,) copies) instead of the whole grid.
+            # No-shift branch only touches top layer, only column 0 copied (instead of whole grid).
             subZ0_old = OUT["subZ"][:, 0].copy()
             subT0_old = OUT["subT"][:, 0].copy()
             subD0_old = OUT["subD"][:, 0].copy()
@@ -108,8 +107,8 @@ def main(C, OUT, IN, dt, grid, phys):
                 + OUT["Dfreshsnow"][is_noshift] * shift[is_noshift] / z0_new
             )
 
-            # Handle shifting updates (vectorized). The shift branch needs full
-            # rows, so snapshot only the (usually few) overflowing columns.
+            # Handle shifting updates (vectorized). Shift branch needs full
+            # rows, so copy only the (usually few) overflowing columns.
             if np.any(is_shift):
                 idx = np.flatnonzero(is_shift)
                 subZ_old = OUT["subZ"][idx]
@@ -179,8 +178,7 @@ def main(C, OUT, IN, dt, grid, phys):
 
             nl = grid["nl"]
 
-            # The no-shift branch touches only the top layer, so snapshot just
-            # column 0 (cheap (gpsum,) copies) instead of the whole grid.
+            # No-shift branch only touches top layer, only column 0 copied (instead of whole grid).
             subZ0_old = OUT["subZ"][:, 0].copy()
             subT0_old = OUT["subT"][:, 0].copy()
             subD0_old = OUT["subD"][:, 0].copy()
@@ -197,7 +195,7 @@ def main(C, OUT, IN, dt, grid, phys):
             temp = z0_new / subZ0_old[noshift]
             OUT["subW"][noshift, 0] = subW0_old[noshift] * temp
 
-            # Handle the shift case: snapshot only the shift rows.
+            # Handle the shift case: copy only the shift rows.
             if idx_shift.size:
                 subZ_old = OUT["subZ"][idx_shift]
                 subT_old = OUT["subT"][idx_shift]
@@ -430,9 +428,8 @@ def main(C, OUT, IN, dt, grid, phys):
         """
         # ------ Heat Conduction Loop ------
         if get_backend() == ComputeBackend.NUMBA:
-            # Numba parallel path: the per-column precompute that the NumPy branch
-            # below does in host NumPy is done in _heat_conduction_prep_kernel
-            # (prange over gpsum); the CFL solve then runs in _heat_conduction_kernel.
+            # Numba parallel path
+            # per-column precompute + CFL solve is done in _heat_conduction_prep_kernel
             gpsum, nl = OUT["subT"].shape
             kk = np.empty((gpsum, nl))
             c_eff = np.empty((gpsum, nl))
@@ -496,9 +493,9 @@ def main(C, OUT, IN, dt, grid, phys):
             )
             assert (dt_stab > 0).all(), "cells with dt_stab <= 0 are forbidden!"
 
-            # Precompute kk*subZ products and the temperature-update denominators once.
-            # kk_sz_top: conductivity-thickness product for the top interface;
-            # kk_sz_interior: same for all interior interfaces.
+            # Precompute kk*subZ products and the temperature-update denominators once
+            # kk_sz_top: conductivity-thickness product for the top interface
+            # kk_sz_interior: same for all interior interfaces
             kk_sz_top = kk[:, 0] * OUT["subZ"][:, 0] + 0.5 * kk[:, 1] * OUT["subZ"][:, 1]
             kk_sz_interior = kk[:, 1:-1] * OUT["subZ"][:, 1:-1] + kk[:, 2:] * OUT["subZ"][:, 2:]
             # denom_layer1: first active layer (layer 0: surface ghost layer overwritten from Tsurf)
@@ -831,9 +828,9 @@ def main(C, OUT, IN, dt, grid, phys):
             # Merge Layers (Accumulation Case)
             idx_merge = np.flatnonzero((OUT["subZ"][:, split] <= threshold) & mask1)
             if idx_merge.size:
-                # Snapshot only the affected rows. Advanced indexing returns a
-                # fresh copy, so these hold the pre-merge values while we write
-                # OUT in place -- without copying the whole (gpsum, nl) grid.
+                # Snapshot only affected rows. Advanced indexing returns fresh
+                # copy (holds pre-merge values). OUT written in place, without
+                # necessity to copy whole (gpsum, nl) grid.
                 subZ_old = OUT["subZ"][idx_merge]
                 subD_old = OUT["subD"][idx_merge]
                 subW_old = OUT["subW"][idx_merge]

--- a/src/ebfm/core/LOOP_SNOW.py
+++ b/src/ebfm/core/LOOP_SNOW.py
@@ -39,6 +39,7 @@ def main(C, OUT, IN, dt, grid, phys):
 
     logger.debug("Starting LOOP_SNOW...")
 
+    @profile
     def snowfall_and_deposition():
         """
         Calculate snowfall and deposition and shift vertical grid accordingly
@@ -132,6 +133,7 @@ def main(C, OUT, IN, dt, grid, phys):
 
         return _SUCCESS
 
+    @profile
     def melt_sublimation():
         """
         Calculate melt and sublimation and shift vertical grid accordingly
@@ -768,6 +770,7 @@ def main(C, OUT, IN, dt, grid, phys):
 
         return _SUCCESS
 
+    @profile
     def layer_merging_and_splitting():
         """
         Layer merging and splitting
@@ -882,6 +885,7 @@ def main(C, OUT, IN, dt, grid, phys):
 
         return _SUCCESS
 
+    @profile
     def runoff():
         ###########################################
         # RUNOFF

--- a/src/ebfm/core/LOOP_SNOW.py
+++ b/src/ebfm/core/LOOP_SNOW.py
@@ -86,55 +86,59 @@ def main(C, OUT, IN, dt, grid, phys):
             shift = np.minimum(shift_tot, max_subZ)
             shift_tot -= shift
 
-            # Use references instead of unnecessary .copy()
-            subT_old = OUT["subT"].copy()
-            subD_old = OUT["subD"].copy()
-            subW_old = OUT["subW"].copy()
-            subZ_old = OUT["subZ"].copy()
+            # The no-shift branch only touches the top layer, so snapshot just
+            # column 0 (cheap (gpsum,) copies) instead of the whole grid.
+            subZ0_old = OUT["subZ"][:, 0].copy()
+            subT0_old = OUT["subT"][:, 0].copy()
+            subD0_old = OUT["subD"][:, 0].copy()
 
             # Precompute conditions for better performance
-            is_noshift = subZ_old[:, 0] + shift <= max_subZ
+            is_noshift = subZ0_old + shift <= max_subZ
             is_shift = ~is_noshift
 
             # Handle no-shift updates (vectorized)
             OUT["subZ"][is_noshift, 0] += shift[is_noshift]
+            z0_new = OUT["subZ"][is_noshift, 0]
             OUT["subT"][is_noshift, 0] = (
-                subT_old[is_noshift, 0] * subZ_old[is_noshift, 0] / OUT["subZ"][is_noshift, 0]
-                + OUT["Tsurf"][is_noshift] * shift[is_noshift] / OUT["subZ"][is_noshift, 0]
+                subT0_old[is_noshift] * subZ0_old[is_noshift] / z0_new
+                + OUT["Tsurf"][is_noshift] * shift[is_noshift] / z0_new
             )
             OUT["subD"][is_noshift, 0] = (
-                subD_old[is_noshift, 0] * subZ_old[is_noshift, 0] / OUT["subZ"][is_noshift, 0]
-                + OUT["Dfreshsnow"][is_noshift] * shift[is_noshift] / OUT["subZ"][is_noshift, 0]
+                subD0_old[is_noshift] * subZ0_old[is_noshift] / z0_new
+                + OUT["Dfreshsnow"][is_noshift] * shift[is_noshift] / z0_new
             )
 
-            # Handle shifting updates (vectorized)
+            # Handle shifting updates (vectorized). The shift branch needs full
+            # rows, so snapshot only the (usually few) overflowing columns.
             if np.any(is_shift):
-                OUT["subZ"][is_shift, 2 : nl - 1] = subZ_old[is_shift, 1 : nl - 2]
-                OUT["subT"][is_shift, 2 : nl - 1] = subT_old[is_shift, 1 : nl - 2]
-                OUT["subD"][is_shift, 2 : nl - 1] = subD_old[is_shift, 1 : nl - 2]
-                OUT["subW"][is_shift, 2 : nl - 1] = subW_old[is_shift, 1 : nl - 2]
+                idx = np.flatnonzero(is_shift)
+                subZ_old = OUT["subZ"][idx]
+                subT_old = OUT["subT"][idx]
+                subD_old = OUT["subD"][idx]
+                subW_old = OUT["subW"][idx]
 
-                OUT["subZ"][is_shift, 1] = max_subZ
-                OUT["subZ"][is_shift, 0] = (subZ_old[is_shift, 0] + shift[is_shift]) - max_subZ
-                OUT["subT"][is_shift, 1] = (
-                    subT_old[is_shift, 0] * subZ_old[is_shift, 0] / OUT["subZ"][is_shift, 1]
-                    + OUT["Tsurf"][is_shift]
-                    * (OUT["subZ"][is_shift, 1] - subZ_old[is_shift, 0])
-                    / OUT["subZ"][is_shift, 1]
-                )
-                OUT["subT"][is_shift, 0] = OUT["Tsurf"][is_shift]
-                OUT["subD"][is_shift, 1] = (
-                    subD_old[is_shift, 0] * subZ_old[is_shift, 0] / OUT["subZ"][is_shift, 1]
-                    + OUT["Dfreshsnow"][is_shift]
-                    * (OUT["subZ"][is_shift, 1] - subZ_old[is_shift, 0])
-                    / OUT["subZ"][is_shift, 1]
-                )
-                OUT["subD"][is_shift, 0] = OUT["Dfreshsnow"][is_shift]
-                OUT["subW"][is_shift, 1] = subW_old[is_shift, 0]
-                OUT["subW"][is_shift, 0] = 0.0
+                OUT["subZ"][idx, 2 : nl - 1] = subZ_old[:, 1 : nl - 2]
+                OUT["subT"][idx, 2 : nl - 1] = subT_old[:, 1 : nl - 2]
+                OUT["subD"][idx, 2 : nl - 1] = subD_old[:, 1 : nl - 2]
+                OUT["subW"][idx, 2 : nl - 1] = subW_old[:, 1 : nl - 2]
 
-            # Update runoff for shifted layers
-            OUT["runoff_irr_deep"][is_shift] += subW_old[is_shift, nl - 1]
+                OUT["subZ"][idx, 1] = max_subZ
+                OUT["subZ"][idx, 0] = (subZ_old[:, 0] + shift[idx]) - max_subZ
+                OUT["subT"][idx, 1] = (
+                    subT_old[:, 0] * subZ_old[:, 0] / OUT["subZ"][idx, 1]
+                    + OUT["Tsurf"][idx] * (OUT["subZ"][idx, 1] - subZ_old[:, 0]) / OUT["subZ"][idx, 1]
+                )
+                OUT["subT"][idx, 0] = OUT["Tsurf"][idx]
+                OUT["subD"][idx, 1] = (
+                    subD_old[:, 0] * subZ_old[:, 0] / OUT["subZ"][idx, 1]
+                    + OUT["Dfreshsnow"][idx] * (OUT["subZ"][idx, 1] - subZ_old[:, 0]) / OUT["subZ"][idx, 1]
+                )
+                OUT["subD"][idx, 0] = OUT["Dfreshsnow"][idx]
+                OUT["subW"][idx, 1] = subW_old[:, 0]
+                OUT["subW"][idx, 0] = 0.0
+
+                # Update runoff for shifted layers
+                OUT["runoff_irr_deep"][idx] += subW_old[:, nl - 1]
 
         return _SUCCESS
 
@@ -173,45 +177,52 @@ def main(C, OUT, IN, dt, grid, phys):
 
             OUT["surfH"] += shift
 
-            # Save old values for updates
-            subT_old = OUT["subT"].copy()
-            subD_old = OUT["subD"].copy()
-            subW_old = OUT["subW"].copy()
-            subZ_old = OUT["subZ"].copy()
+            nl = grid["nl"]
 
-            # Find no-shift and shift indices
-            i_noshift = np.where(subZ_old[:, 0] + shift > 1e-17)
-            i_shift = np.where(subZ_old[:, 0] + shift <= 1e-17)
+            # The no-shift branch touches only the top layer, so snapshot just
+            # column 0 (cheap (gpsum,) copies) instead of the whole grid.
+            subZ0_old = OUT["subZ"][:, 0].copy()
+            subT0_old = OUT["subT"][:, 0].copy()
+            subD0_old = OUT["subD"][:, 0].copy()
+            subW0_old = OUT["subW"][:, 0].copy()
+
+            noshift = subZ0_old + shift > 1e-17
+            idx_shift = np.flatnonzero(~noshift)
 
             # Handle the no-shift case
-            OUT["subZ"][i_noshift, 0] = subZ_old[i_noshift, 0] + shift[i_noshift]
-            OUT["subT"][i_noshift, 0] = subT_old[i_noshift, 0]
-            OUT["subD"][i_noshift, 0] = subD_old[i_noshift, 0]
-            temp = OUT["subZ"][i_noshift, 0] / subZ_old[i_noshift, 0]
-            OUT["subW"][i_noshift, 0] = subW_old[i_noshift, 0] * temp
+            z0_new = subZ0_old[noshift] + shift[noshift]
+            OUT["subZ"][noshift, 0] = z0_new
+            OUT["subT"][noshift, 0] = subT0_old[noshift]
+            OUT["subD"][noshift, 0] = subD0_old[noshift]
+            temp = z0_new / subZ0_old[noshift]
+            OUT["subW"][noshift, 0] = subW0_old[noshift] * temp
 
-            # Handle the shift case
-            nl = grid["nl"]
-            OUT["subZ"][i_shift, 1 : nl - 2] = subZ_old[i_shift, 2 : nl - 1]
-            OUT["subT"][i_shift, 1 : nl - 2] = subT_old[i_shift, 2 : nl - 1]
-            OUT["subD"][i_shift, 1 : nl - 2] = subD_old[i_shift, 2 : nl - 1]
-            OUT["subW"][i_shift, 1 : nl - 2] = subW_old[i_shift, 2 : nl - 1]
+            # Handle the shift case: snapshot only the shift rows.
+            if idx_shift.size:
+                subZ_old = OUT["subZ"][idx_shift]
+                subT_old = OUT["subT"][idx_shift]
+                subD_old = OUT["subD"][idx_shift]
+                subW_old = OUT["subW"][idx_shift]
 
-            OUT["subZ"][i_shift, 0] = subZ_old[i_shift, 0] + subZ_old[i_shift, 1] + shift[i_shift]
-            OUT["subT"][i_shift, 0] = subT_old[i_shift, 1]
-            OUT["subD"][i_shift, 0] = subD_old[i_shift, 1]
-            temp = OUT["subZ"][i_shift, 0] / subZ_old[i_shift, 1]
-            OUT["subW"][i_shift, 0] = subW_old[i_shift, 1] * temp
-            OUT["subT"][i_shift, nl - 1] = subT_old[i_shift, nl - 1]
-            OUT["subW"][i_shift, nl - 1] = 0.0
+                OUT["subZ"][idx_shift, 1 : nl - 2] = subZ_old[:, 2 : nl - 1]
+                OUT["subT"][idx_shift, 1 : nl - 2] = subT_old[:, 2 : nl - 1]
+                OUT["subD"][idx_shift, 1 : nl - 2] = subD_old[:, 2 : nl - 1]
+                OUT["subW"][idx_shift, 1 : nl - 2] = subW_old[:, 2 : nl - 1]
 
-            # Update the deepest layer properties
-            for idx in i_shift:
+                OUT["subZ"][idx_shift, 0] = subZ_old[:, 0] + subZ_old[:, 1] + shift[idx_shift]
+                OUT["subT"][idx_shift, 0] = subT_old[:, 1]
+                OUT["subD"][idx_shift, 0] = subD_old[:, 1]
+                temp = OUT["subZ"][idx_shift, 0] / subZ_old[:, 1]
+                OUT["subW"][idx_shift, 0] = subW_old[:, 1] * temp
+                OUT["subT"][idx_shift, nl - 1] = subT_old[:, nl - 1]
+                OUT["subW"][idx_shift, nl - 1] = 0.0
+
+                # Update the deepest layer properties (vectorized over shift rows)
                 if grid["doubledepth"] == 1:
-                    OUT["subZ"][idx, nl - 1] = 2.0 ** len(grid["split"]) * grid["max_subZ"]
+                    OUT["subZ"][idx_shift, nl - 1] = 2.0 ** len(grid["split"]) * grid["max_subZ"]
                 else:
-                    OUT["subZ"][idx, nl - 1] = grid["max_subZ"]
-                OUT["subD"][idx, nl - 1] = subD_old[idx, nl - 1]
+                    OUT["subZ"][idx_shift, nl - 1] = grid["max_subZ"]
+                OUT["subD"][idx_shift, nl - 1] = subD_old[:, nl - 1]
 
         return _SUCCESS
 

--- a/src/ebfm/core/LOOP_SNOW.py
+++ b/src/ebfm/core/LOOP_SNOW.py
@@ -784,87 +784,66 @@ def main(C, OUT, IN, dt, grid, phys):
         nsplit = len(grid["split"])
         top_thickness = (2.0**nsplit) * max_subZ
 
-        # Reuse persistent buffers instead of allocating new .copy() arrays
-        shp = OUT["subZ"].shape
-        if "_lm_old_subZ" not in OUT or OUT["_lm_old_subZ"].shape != shp:
-            OUT["_lm_old_subZ"] = np.empty_like(OUT["subZ"])
-            OUT["_lm_old_subD"] = np.empty_like(OUT["subD"])
-            OUT["_lm_old_subW"] = np.empty_like(OUT["subW"])
-            OUT["_lm_old_subT"] = np.empty_like(OUT["subT"])
-            OUT["_lm_old_subS"] = np.empty_like(OUT["subS"])
-
         for n in range(nsplit):  # Iterate through split points
             split = grid["split"][n]
             threshold = (2.0**n) * max_subZ
 
             # Merge Layers (Accumulation Case)
             idx_merge = np.flatnonzero((OUT["subZ"][:, split] <= threshold) & mask1)
-
-            np.copyto(OUT["_lm_old_subZ"], OUT["subZ"])
-            np.copyto(OUT["_lm_old_subD"], OUT["subD"])
-            np.copyto(OUT["_lm_old_subW"], OUT["subW"])
-            np.copyto(OUT["_lm_old_subT"], OUT["subT"])
-            np.copyto(OUT["_lm_old_subS"], OUT["subS"])
-
-            subZ_old = OUT["_lm_old_subZ"]
-            subD_old = OUT["_lm_old_subD"]
-            subW_old = OUT["_lm_old_subW"]
-            subT_old = OUT["_lm_old_subT"]
-            subS_old = OUT["_lm_old_subS"]
-
             if idx_merge.size:
+                # Snapshot only the affected rows. Advanced indexing returns a
+                # fresh copy, so these hold the pre-merge values while we write
+                # OUT in place -- without copying the whole (gpsum, nl) grid.
+                subZ_old = OUT["subZ"][idx_merge]
+                subD_old = OUT["subD"][idx_merge]
+                subW_old = OUT["subW"][idx_merge]
+                subT_old = OUT["subT"][idx_merge]
+                subS_old = OUT["subS"][idx_merge]
+
                 # Update merged layers
-                OUT["subZ"][idx_merge, split - 1] = subZ_old[idx_merge, split - 1] + subZ_old[idx_merge, split]
-                OUT["subW"][idx_merge, split - 1] = subW_old[idx_merge, split - 1] + subW_old[idx_merge, split]
-                OUT["subS"][idx_merge, split - 1] = subS_old[idx_merge, split - 1] + subS_old[idx_merge, split]
+                OUT["subZ"][idx_merge, split - 1] = subZ_old[:, split - 1] + subZ_old[:, split]
+                OUT["subW"][idx_merge, split - 1] = subW_old[:, split - 1] + subW_old[:, split]
+                OUT["subS"][idx_merge, split - 1] = subS_old[:, split - 1] + subS_old[:, split]
 
                 # Compute denominator once and reuse
-                den = subZ_old[idx_merge, split - 1] + subZ_old[idx_merge, split]
+                den = subZ_old[:, split - 1] + subZ_old[:, split]
                 OUT["subD"][idx_merge, split - 1] = (
-                    subZ_old[idx_merge, split - 1] * subD_old[idx_merge, split - 1]
-                    + subZ_old[idx_merge, split] * subD_old[idx_merge, split]
+                    subZ_old[:, split - 1] * subD_old[:, split - 1] + subZ_old[:, split] * subD_old[:, split]
                 ) / den
                 OUT["subT"][idx_merge, split - 1] = (
-                    subZ_old[idx_merge, split - 1] * subT_old[idx_merge, split - 1]
-                    + subZ_old[idx_merge, split] * subT_old[idx_merge, split]
+                    subZ_old[:, split - 1] * subT_old[:, split - 1] + subZ_old[:, split] * subT_old[:, split]
                 ) / den
 
                 # Shift properties up for merged layers
-                OUT["subZ"][idx_merge, split:-1] = subZ_old[idx_merge, split + 1 :]
-                OUT["subW"][idx_merge, split:-1] = subW_old[idx_merge, split + 1 :]
-                OUT["subS"][idx_merge, split:-1] = subS_old[idx_merge, split + 1 :]
-                OUT["subD"][idx_merge, split:-1] = subD_old[idx_merge, split + 1 :]
-                OUT["subT"][idx_merge, split:-1] = subT_old[idx_merge, split + 1 :]
+                OUT["subZ"][idx_merge, split:-1] = subZ_old[:, split + 1 :]
+                OUT["subW"][idx_merge, split:-1] = subW_old[:, split + 1 :]
+                OUT["subS"][idx_merge, split:-1] = subS_old[:, split + 1 :]
+                OUT["subD"][idx_merge, split:-1] = subD_old[:, split + 1 :]
+                OUT["subT"][idx_merge, split:-1] = subT_old[:, split + 1 :]
 
                 # Adjust the newly added layer at the base
                 OUT["subZ"][idx_merge, -1] = top_thickness
-                OUT["subT"][idx_merge, -1] = subT_old[idx_merge, -1]
-                OUT["subD"][idx_merge, -1] = subD_old[idx_merge, -1]
+                OUT["subT"][idx_merge, -1] = subT_old[:, -1]
+                OUT["subD"][idx_merge, -1] = subD_old[:, -1]
                 OUT["subW"][idx_merge, -1] = 0.0
                 OUT["subS"][idx_merge, -1] = 0.0
 
-            # Split Layers (Ablation Case)
+            # Split Layers (Ablation Case). idx_split reflects the post-merge state.
             idx_split = np.flatnonzero((OUT["subZ"][:, split - 2] > threshold) & mask1)
-
-            np.copyto(OUT["_lm_old_subZ"], OUT["subZ"])
-            np.copyto(OUT["_lm_old_subD"], OUT["subD"])
-            np.copyto(OUT["_lm_old_subW"], OUT["subW"])
-            np.copyto(OUT["_lm_old_subT"], OUT["subT"])
-            np.copyto(OUT["_lm_old_subS"], OUT["subS"])
-
-            subZ_old = OUT["_lm_old_subZ"]
-            subD_old = OUT["_lm_old_subD"]
-            subW_old = OUT["_lm_old_subW"]
-            subT_old = OUT["_lm_old_subT"]
-            subS_old = OUT["_lm_old_subS"]
-
             if idx_split.size:
+                # Snapshot only the affected rows (post-merge values).
+                subZ_old = OUT["subZ"][idx_split]
+                subD_old = OUT["subD"][idx_split]
+                subW_old = OUT["subW"][idx_split]
+                subT_old = OUT["subT"][idx_split]
+                subS_old = OUT["subS"][idx_split]
+
                 # Update split layers
                 OUT["subZ"][idx_split, split - 2] *= 0.5
                 OUT["subW"][idx_split, split - 2] *= 0.5
                 OUT["subS"][idx_split, split - 2] *= 0.5
-                OUT["subT"][idx_split, split - 2] = subT_old[idx_split, split - 2]
-                OUT["subD"][idx_split, split - 2] = subD_old[idx_split, split - 2]
+                OUT["subT"][idx_split, split - 2] = subT_old[:, split - 2]
+                OUT["subD"][idx_split, split - 2] = subD_old[:, split - 2]
 
                 OUT["subZ"][idx_split, split - 1] = OUT["subZ"][idx_split, split - 2]
                 OUT["subW"][idx_split, split - 1] = OUT["subW"][idx_split, split - 2]
@@ -873,15 +852,15 @@ def main(C, OUT, IN, dt, grid, phys):
                 OUT["subD"][idx_split, split - 1] = OUT["subD"][idx_split, split - 2]
 
                 # Shift properties down for split layers
-                OUT["subZ"][idx_split, split:] = subZ_old[idx_split, split - 1 : -1]
-                OUT["subW"][idx_split, split:] = subW_old[idx_split, split - 1 : -1]
-                OUT["subS"][idx_split, split:] = subS_old[idx_split, split - 1 : -1]
-                OUT["subT"][idx_split, split:] = subT_old[idx_split, split - 1 : -1]
-                OUT["subD"][idx_split, split:] = subD_old[idx_split, split - 1 : -1]
+                OUT["subZ"][idx_split, split:] = subZ_old[:, split - 1 : -1]
+                OUT["subW"][idx_split, split:] = subW_old[:, split - 1 : -1]
+                OUT["subS"][idx_split, split:] = subS_old[:, split - 1 : -1]
+                OUT["subT"][idx_split, split:] = subT_old[:, split - 1 : -1]
+                OUT["subD"][idx_split, split:] = subD_old[:, split - 1 : -1]
 
                 # Update runoff contributions
-                OUT["runoff_irr_deep"][idx_split] += subW_old[idx_split, -1]
-                OUT["runoff_slush"][idx_split] += subS_old[idx_split, -1]
+                OUT["runoff_irr_deep"][idx_split] += subW_old[:, -1]
+                OUT["runoff_slush"][idx_split] += subS_old[:, -1]
 
         return _SUCCESS
 

--- a/src/ebfm/core/LOOP_SNOW.py
+++ b/src/ebfm/core/LOOP_SNOW.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import numpy as np
+from numpy.typing import NDArray
 
 from .compute_backend import get_backend, ComputeBackend
 from .constants import SECONDS_PER_HOUR
@@ -23,6 +24,10 @@ except NameError:
 from ebfm.core import logging
 
 _SUCCESS = True
+
+# Layer thicknesses (m) below this count as zero, i.e. the layer is melted away.
+# Adapted from initial commit 42c0113
+_MIN_LAYER_THICKNESS = 1e-17
 
 logger = logging.getLogger(__name__)
 
@@ -83,61 +88,68 @@ def main(C, OUT, IN, dt, grid, phys):
 
         # Main processing loop: Run until all shifts are handled
         while np.any(shift_tot > 0):
-            shift = np.minimum(shift_tot, max_subZ)
-            shift_tot -= shift
+            # Fresh snow thickness (m) deposited in this pass, at most one full layer
+            shift_amount = np.minimum(shift_tot, max_subZ)
+            shift_tot -= shift_amount
 
             # No-shift branch only touches top layer, only column 0 copied (instead of whole grid).
-            subZ0_old = OUT["subZ"][:, 0].copy()
-            subT0_old = OUT["subT"][:, 0].copy()
-            subD0_old = OUT["subD"][:, 0].copy()
+            subZ_top_old = OUT["subZ"][:, 0].copy()
+            subT_top_old = OUT["subT"][:, 0].copy()
+            subD_top_old = OUT["subD"][:, 0].copy()
 
-            # Precompute conditions for better performance
-            is_noshift = subZ0_old + shift <= max_subZ
-            is_shift = ~is_noshift
+            # A "grid shift" moves the layer indices: an overfull top layer becomes
+            # layer 1, deeper layers move down, the overflow starts a new top layer.
+            no_grid_shift: NDArray[np.bool_] = subZ_top_old + shift_amount <= max_subZ
+            needs_grid_shift: NDArray[np.bool_] = ~no_grid_shift
+            # Index into the grid with indices, not with the masks, reason: NumPy
+            # re-scans the full mask on every indexing operation, flatnonzero pays that
+            # scan once and each later access then costs only the affected rows.
+            idx_noshift: NDArray[np.intp] = np.flatnonzero(no_grid_shift)
+            idx_shift: NDArray[np.intp] = np.flatnonzero(needs_grid_shift)
 
             # Handle no-shift updates (vectorized)
-            OUT["subZ"][is_noshift, 0] += shift[is_noshift]
-            z0_new = OUT["subZ"][is_noshift, 0]
-            OUT["subT"][is_noshift, 0] = (
-                subT0_old[is_noshift] * subZ0_old[is_noshift] / z0_new
-                + OUT["Tsurf"][is_noshift] * shift[is_noshift] / z0_new
+            OUT["subZ"][idx_noshift, 0] += shift_amount[idx_noshift]
+            subZ_top_new = OUT["subZ"][idx_noshift, 0]
+            OUT["subT"][idx_noshift, 0] = (
+                subT_top_old[idx_noshift] * subZ_top_old[idx_noshift] / subZ_top_new
+                + OUT["Tsurf"][idx_noshift] * shift_amount[idx_noshift] / subZ_top_new
             )
-            OUT["subD"][is_noshift, 0] = (
-                subD0_old[is_noshift] * subZ0_old[is_noshift] / z0_new
-                + OUT["Dfreshsnow"][is_noshift] * shift[is_noshift] / z0_new
+            OUT["subD"][idx_noshift, 0] = (
+                subD_top_old[idx_noshift] * subZ_top_old[idx_noshift] / subZ_top_new
+                + OUT["Dfreshsnow"][idx_noshift] * shift_amount[idx_noshift] / subZ_top_new
             )
 
             # Handle shifting updates (vectorized). Shift branch needs full
             # rows, so copy only the (usually few) overflowing columns.
-            if np.any(is_shift):
-                idx = np.flatnonzero(is_shift)
-                subZ_old = OUT["subZ"][idx]
-                subT_old = OUT["subT"][idx]
-                subD_old = OUT["subD"][idx]
-                subW_old = OUT["subW"][idx]
+            if idx_shift.size:
+                subZ_old = OUT["subZ"][idx_shift]
+                subT_old = OUT["subT"][idx_shift]
+                subD_old = OUT["subD"][idx_shift]
+                subW_old = OUT["subW"][idx_shift]
 
-                OUT["subZ"][idx, 2 : nl - 1] = subZ_old[:, 1 : nl - 2]
-                OUT["subT"][idx, 2 : nl - 1] = subT_old[:, 1 : nl - 2]
-                OUT["subD"][idx, 2 : nl - 1] = subD_old[:, 1 : nl - 2]
-                OUT["subW"][idx, 2 : nl - 1] = subW_old[:, 1 : nl - 2]
+                OUT["subZ"][idx_shift, 2 : nl - 1] = subZ_old[:, 1 : nl - 2]
+                OUT["subT"][idx_shift, 2 : nl - 1] = subT_old[:, 1 : nl - 2]
+                OUT["subD"][idx_shift, 2 : nl - 1] = subD_old[:, 1 : nl - 2]
+                OUT["subW"][idx_shift, 2 : nl - 1] = subW_old[:, 1 : nl - 2]
 
-                OUT["subZ"][idx, 1] = max_subZ
-                OUT["subZ"][idx, 0] = (subZ_old[:, 0] + shift[idx]) - max_subZ
-                OUT["subT"][idx, 1] = (
-                    subT_old[:, 0] * subZ_old[:, 0] / OUT["subZ"][idx, 1]
-                    + OUT["Tsurf"][idx] * (OUT["subZ"][idx, 1] - subZ_old[:, 0]) / OUT["subZ"][idx, 1]
+                OUT["subZ"][idx_shift, 1] = max_subZ
+                OUT["subZ"][idx_shift, 0] = (subZ_old[:, 0] + shift_amount[idx_shift]) - max_subZ
+                subZ_layer1_new = OUT["subZ"][idx_shift, 1]
+                OUT["subT"][idx_shift, 1] = (
+                    subT_old[:, 0] * subZ_old[:, 0] / subZ_layer1_new
+                    + OUT["Tsurf"][idx_shift] * (subZ_layer1_new - subZ_old[:, 0]) / subZ_layer1_new
                 )
-                OUT["subT"][idx, 0] = OUT["Tsurf"][idx]
-                OUT["subD"][idx, 1] = (
-                    subD_old[:, 0] * subZ_old[:, 0] / OUT["subZ"][idx, 1]
-                    + OUT["Dfreshsnow"][idx] * (OUT["subZ"][idx, 1] - subZ_old[:, 0]) / OUT["subZ"][idx, 1]
+                OUT["subT"][idx_shift, 0] = OUT["Tsurf"][idx_shift]
+                OUT["subD"][idx_shift, 1] = (
+                    subD_old[:, 0] * subZ_old[:, 0] / subZ_layer1_new
+                    + OUT["Dfreshsnow"][idx_shift] * (subZ_layer1_new - subZ_old[:, 0]) / subZ_layer1_new
                 )
-                OUT["subD"][idx, 0] = OUT["Dfreshsnow"][idx]
-                OUT["subW"][idx, 1] = subW_old[:, 0]
-                OUT["subW"][idx, 0] = 0.0
+                OUT["subD"][idx_shift, 0] = OUT["Dfreshsnow"][idx_shift]
+                OUT["subW"][idx_shift, 1] = subW_old[:, 0]
+                OUT["subW"][idx_shift, 0] = 0.0
 
                 # Update runoff for shifted layers
-                OUT["runoff_irr_deep"][idx] += subW_old[:, nl - 1]
+                OUT["runoff_irr_deep"][idx_shift] += subW_old[:, nl - 1]
 
         return _SUCCESS
 
@@ -171,29 +183,35 @@ def main(C, OUT, IN, dt, grid, phys):
 
         # While there are shifts required
         while np.any(shift_tot < 0):
-            shift = np.maximum(shift_tot, -OUT["subZ"][:, 1])
-            shift_tot -= shift
+            # Thickness (m, negative) removed in this pass, at most the top two layers
+            shift_amount = np.maximum(shift_tot, -OUT["subZ"][:, 1])
+            shift_tot -= shift_amount
 
-            OUT["surfH"] += shift
+            OUT["surfH"] += shift_amount
 
             nl = grid["nl"]
 
             # No-shift branch only touches top layer, only column 0 copied (instead of whole grid).
-            subZ0_old = OUT["subZ"][:, 0].copy()
-            subT0_old = OUT["subT"][:, 0].copy()
-            subD0_old = OUT["subD"][:, 0].copy()
-            subW0_old = OUT["subW"][:, 0].copy()
+            subZ_top_old = OUT["subZ"][:, 0].copy()
+            subT_top_old = OUT["subT"][:, 0].copy()
+            subD_top_old = OUT["subD"][:, 0].copy()
+            subW_top_old = OUT["subW"][:, 0].copy()
 
-            noshift = subZ0_old + shift > 1e-17
-            idx_shift = np.flatnonzero(~noshift)
+            # A "grid shift" moves the layer indices: a fully melted top layer is
+            # dropped, layer 1 becomes the new top layer, deeper layers move up.
+            # See snowfall_and_deposition() for explanation of the indexing strategy.
+            no_grid_shift: NDArray[np.bool_] = subZ_top_old + shift_amount > _MIN_LAYER_THICKNESS
+            needs_grid_shift: NDArray[np.bool_] = ~no_grid_shift
+            idx_noshift: NDArray[np.intp] = np.flatnonzero(no_grid_shift)
+            idx_shift: NDArray[np.intp] = np.flatnonzero(needs_grid_shift)
 
             # Handle the no-shift case
-            z0_new = subZ0_old[noshift] + shift[noshift]
-            OUT["subZ"][noshift, 0] = z0_new
-            OUT["subT"][noshift, 0] = subT0_old[noshift]
-            OUT["subD"][noshift, 0] = subD0_old[noshift]
-            temp = z0_new / subZ0_old[noshift]
-            OUT["subW"][noshift, 0] = subW0_old[noshift] * temp
+            subZ_top_new = subZ_top_old[idx_noshift] + shift_amount[idx_noshift]
+            OUT["subZ"][idx_noshift, 0] = subZ_top_new
+            OUT["subT"][idx_noshift, 0] = subT_top_old[idx_noshift]
+            OUT["subD"][idx_noshift, 0] = subD_top_old[idx_noshift]
+            # Liquid water scales with the remaining fraction of the top layer
+            OUT["subW"][idx_noshift, 0] = subW_top_old[idx_noshift] * (subZ_top_new / subZ_top_old[idx_noshift])
 
             # Handle the shift case: copy only the shift rows.
             if idx_shift.size:
@@ -207,11 +225,12 @@ def main(C, OUT, IN, dt, grid, phys):
                 OUT["subD"][idx_shift, 1 : nl - 2] = subD_old[:, 2 : nl - 1]
                 OUT["subW"][idx_shift, 1 : nl - 2] = subW_old[:, 2 : nl - 1]
 
-                OUT["subZ"][idx_shift, 0] = subZ_old[:, 0] + subZ_old[:, 1] + shift[idx_shift]
+                subZ_top_new = subZ_old[:, 0] + subZ_old[:, 1] + shift_amount[idx_shift]
+                OUT["subZ"][idx_shift, 0] = subZ_top_new
                 OUT["subT"][idx_shift, 0] = subT_old[:, 1]
                 OUT["subD"][idx_shift, 0] = subD_old[:, 1]
-                temp = OUT["subZ"][idx_shift, 0] / subZ_old[:, 1]
-                OUT["subW"][idx_shift, 0] = subW_old[:, 1] * temp
+                # Liquid water scales with the remaining fraction of the former layer 1
+                OUT["subW"][idx_shift, 0] = subW_old[:, 1] * (subZ_top_new / subZ_old[:, 1])
                 OUT["subT"][idx_shift, nl - 1] = subT_old[:, nl - 1]
                 OUT["subW"][idx_shift, nl - 1] = 0.0
 
@@ -290,7 +309,6 @@ def main(C, OUT, IN, dt, grid, phys):
             # NumPy path
             subD_old = OUT["subD"].copy()
             subZ_old = OUT["subZ"].copy()
-            mliqmax = np.zeros((gpsum, nl))
             # ------ FIRN COMPACTION ------ #
             if phys["snow_compaction"] in ["firn_only", "firn+snow"]:
                 # Pre-compute the logical condition based on the snow compaction type
@@ -402,7 +420,9 @@ def main(C, OUT, IN, dt, grid, phys):
             # Update layer thickness
             OUT["subZ"][cond_layers] = subZ_old[cond_layers] * subD_old[cond_layers] / OUT["subD"][cond_layers]
 
-            # Update irreducible water storage
+            # Update irreducible water storage: `mliqmax` is the maximum liquid water
+            # (kg m-2) a layer holds against gravity; ice layers keep 0.0 and drain fully
+            mliqmax = np.zeros((gpsum, nl))
             exp_factor = 0.0143 * np.exp(3.3 * (Dice - OUT["subD"][cond_layers]) / Dice)
             mliqmax[cond_layers] = (
                 OUT["subD"][cond_layers]

--- a/src/ebfm/core/LOOP_SNOW.py
+++ b/src/ebfm/core/LOOP_SNOW.py
@@ -235,10 +235,6 @@ def main(C, OUT, IN, dt, grid, phys):
         gpsum, nl = grid["gpsum"], grid["nl"]
         Dice, Dfirn = C["Dice"], C["Dfirn"]
 
-        subD_old = OUT["subD"].copy()
-        subZ_old = OUT["subZ"].copy()
-        mliqmax = np.zeros((gpsum, nl))
-
         dt_yearfrac = dt / C["yeardays"]
         dt_seconds = dt * C["dayseconds"]
 
@@ -268,8 +264,6 @@ def main(C, OUT, IN, dt, grid, phys):
                 OUT["subT"],
                 OUT["subW"],
                 OUT["subTmean"],
-                subD_old,
-                subZ_old,
                 IN["logyearsnow"],
                 IN["yearsnow"],
                 IN["WS"],
@@ -296,6 +290,9 @@ def main(C, OUT, IN, dt, grid, phys):
             )
         else:
             # NumPy path
+            subD_old = OUT["subD"].copy()
+            subZ_old = OUT["subZ"].copy()
+            mliqmax = np.zeros((gpsum, nl))
             # ------ FIRN COMPACTION ------ #
             if phys["snow_compaction"] in ["firn_only", "firn+snow"]:
                 # Pre-compute the logical condition based on the snow compaction type
@@ -572,7 +569,6 @@ def main(C, OUT, IN, dt, grid, phys):
         #########################################################
         # Percolation, refreezing and irreducible water storage
         #########################################################
-        subW_old = OUT["subW"].copy()  # Store the old water content
         gpsum, nl = OUT["subT"].shape
 
         if get_backend() == ComputeBackend.NUMBA:
@@ -604,7 +600,6 @@ def main(C, OUT, IN, dt, grid, phys):
                 OUT["subW"],
                 OUT["subS"],
                 OUT["subZ"],
-                subW_old,
                 _avail_W,
                 OUT["_perc_RP"],
                 _runoff_surface,
@@ -634,6 +629,7 @@ def main(C, OUT, IN, dt, grid, phys):
             OUT["cpi"] = 152.2 + 7.122 * OUT["subT"]
         else:
             # NumPy path
+            subW_old = OUT["subW"].copy()  # Store the old water content
             # ------ Water Input ------
             avail_W = (
                 OUT["melt"] * 1e3  # Meltwater

--- a/src/ebfm/core/LOOP_SNOW_kernels.py
+++ b/src/ebfm/core/LOOP_SNOW_kernels.py
@@ -163,6 +163,84 @@ def _compaction_kernel(
 
 
 @njit(parallel=True, cache=True)
+def _heat_conduction_prep_kernel(
+    subD,  # (gpsum, nl)
+    subZ,  # (gpsum, nl)
+    subT,  # (gpsum, nl)
+    kk,  # (gpsum, nl)      out: effective conductivity
+    c_eff,  # (gpsum, nl)      out: volumetric heat capacity
+    kk_sz_top,  # (gpsum,)         out
+    kk_sz_interior,  # (gpsum, nl-2)    out
+    dz1,  # (gpsum,)         out
+    dz2,  # (gpsum, nl-2)    out
+    denom_layer1,  # (gpsum,)         out
+    denom_interior,  # (gpsum, nl-3)    out
+    denom_bottom,  # (gpsum,)         out
+    dt_stab,  # (gpsum,)         out
+    dayseconds,  # scalar
+):
+    """Per-column heat-conduction precompute, parallelized over gpsum.
+
+    Produces the derived arrays (conductivity, heat capacity, interface
+    conductivity-thickness products, squared inter-layer distances, update
+    denominators and the CFL stability step) that _heat_conduction_kernel
+    consumes, directly from the resident subD/subZ/subT without a host-side
+    NumPy round-trip.
+
+    Every expression mirrors the NumPy precompute in
+    LOOP_SNOW.heat_conduction() operation-for-operation (including
+    parenthesization such as ``3.233e-6 * (d * d)`` and ``0.5 * (s * s)``) so
+    the result is bit-identical to the NumPy/host-precompute path.
+    """
+    gpsum, nl = subD.shape
+    for i in prange(gpsum):
+        # Effective conductivity and volumetric heat capacity per layer.
+        for k in range(nl):
+            d = subD[i, k]
+            kk[i, k] = 0.138 - 1.01e-3 * d + 3.233e-6 * (d * d)
+            c_eff[i, k] = d * (152.2 + 7.122 * subT[i, k])
+
+        # dz1 = (subZ[0] + 0.5*subZ[1])**2
+        half1 = subZ[i, 0] + 0.5 * subZ[i, 1]
+        dz1[i] = half1 * half1
+
+        # dz2 = 0.5 * (subZ[k+2] + subZ[k+1])**2
+        for k in range(nl - 2):
+            s = subZ[i, k + 2] + subZ[i, k + 1]
+            dz2[i, k] = 0.5 * (s * s)
+
+        # kk_sz_top = kk[0]*subZ[0] + 0.5*kk[1]*subZ[1]
+        kk_sz_top[i] = kk[i, 0] * subZ[i, 0] + 0.5 * kk[i, 1] * subZ[i, 1]
+
+        # kk_sz_interior[j] = kk[j+1]*subZ[j+1] + kk[j+2]*subZ[j+2]
+        for k in range(nl - 2):
+            kk_sz_interior[i, k] = kk[i, k + 1] * subZ[i, k + 1] + kk[i, k + 2] * subZ[i, k + 2]
+
+        # denom_layer1 = c_eff[1] * (0.5*subZ[0] + 0.5*subZ[1] + 0.25*subZ[2])
+        denom_layer1[i] = c_eff[i, 1] * (0.5 * subZ[i, 0] + 0.5 * subZ[i, 1] + 0.25 * subZ[i, 2])
+
+        # denom_interior[k-2] = c_eff[k] * (0.25*subZ[k-1] + 0.5*subZ[k] + 0.25*subZ[k+1]), k in 2..nl-2
+        for k in range(2, nl - 1):
+            denom_interior[i, k - 2] = c_eff[i, k] * (0.25 * subZ[i, k - 1] + 0.5 * subZ[i, k] + 0.25 * subZ[i, k + 1])
+
+        # denom_bottom = c_eff[-1] * (0.25*subZ[-2] + 0.75*subZ[-1])
+        denom_bottom[i] = c_eff[i, nl - 1] * (0.25 * subZ[i, nl - 2] + 0.75 * subZ[i, nl - 1])
+
+        # dt_stab = 0.5 * min(c_eff[1:]) * min(subZ[1:])**2 / max(kk[1:]) / dayseconds
+        min_ceff = math.inf
+        min_sz = math.inf
+        max_kk = 0.0
+        for k in range(1, nl):
+            if c_eff[i, k] < min_ceff:
+                min_ceff = c_eff[i, k]
+            if subZ[i, k] < min_sz:
+                min_sz = subZ[i, k]
+            if kk[i, k] > max_kk:
+                max_kk = kk[i, k]
+        dt_stab[i] = 0.5 * min_ceff * (min_sz * min_sz) / max_kk / dayseconds
+
+
+@njit(parallel=True, cache=True)
 def _heat_conduction_kernel(
     subT,  # (gpsum, nl) Output array, updated in-place
     Tsurf,  # (gpsum,)

--- a/src/ebfm/core/LOOP_SNOW_kernels.py
+++ b/src/ebfm/core/LOOP_SNOW_kernels.py
@@ -30,8 +30,6 @@ def _compaction_kernel(
     subT,  # (gpsum, nl)
     subW,  # (gpsum, nl), Output array
     subTmean,  # (gpsum, nl) Output array, updated in-place
-    subD_old,  # (gpsum, nl)
-    subZ_old,  # (gpsum, nl)
     logyearsnow,  # (gpsum, nl)
     yearsnow,  # (gpsum, nl)
     WS,  # (gpsum,)
@@ -67,6 +65,12 @@ def _compaction_kernel(
     """
     gpsum, nl = subD.shape
     for i in prange(gpsum):
+        # Snapshot this column's pre-compaction density and thickness (used for
+        # the layer-thickness update in section 3). Done per-thread here instead
+        # of copying the whole grid on the host before the launch.
+        subD_old = subD[i, :].copy()
+        subZ_old = subZ[i, :].copy()
+
         # ------ 1. FIRN COMPACTION ------ #
         for k in range(nl):
             subTmean[i, k] = subTmean[i, k] * (1.0 - dt_yearfrac) + dt_yearfrac * subT[i, k]
@@ -145,7 +149,7 @@ def _compaction_kernel(
         subW_sum = 0.0
         for k in range(nl):
             if subD[i, k] < Dice:
-                subZ[i, k] = subZ_old[i, k] * subD_old[i, k] / subD[i, k]
+                subZ[i, k] = subZ_old[k] * subD_old[k] / subD[i, k]
                 exp_f = 0.0143 * math.exp(3.3 * (Dice - subD[i, k]) / Dice)
                 denom = 1.0 - exp_f
                 mliqmax_k = subD[i, k] * subZ[i, k] * exp_f / denom * 0.05 * min(Dice - subD[i, k], 20.0)
@@ -155,7 +159,7 @@ def _compaction_kernel(
                 # Ice layer: mliqmax = 0 => clamp subW to zero
                 subW[i, k] = 0.0
             z_sum += subZ[i, k]
-            z_sum_old += subZ_old[i, k]
+            z_sum_old += subZ_old[k]
             subW_sum += subW[i, k]
 
         surfH[i] += z_sum - z_sum_old
@@ -304,7 +308,6 @@ def _percolation_kernel(
     subW,  # (gpsum, nl) Output array, updated in-place
     subS,  # (gpsum, nl) Output array, rewritten
     subZ,  # (gpsum, nl)
-    subW_old,  # (gpsum, nl)
     avail_W,  # (gpsum,)
     RP,  # (gpsum, nl)
     runoff_surface,  # (gpsum,)
@@ -338,6 +341,10 @@ def _percolation_kernel(
     trunoff_factor = 1.0 / (1.0 + dt / Trunoff)
 
     for i in prange(gpsum):
+        # Snapshot this column's pre-percolation water content, instead of
+        # copying the whole grid on the host before the launch.
+        subW_old = subW[i, :].copy()
+
         # ------ Refreezing and Irreducible Water Storage Limits ------
         # Compute refreezing potential (`Wlim`) per layer
         # Compute maximum irreducible water storage (`mliqmax`)
@@ -356,7 +363,7 @@ def _percolation_kernel(
                 mliqmax_k = subD[i, k] * subZ[i, k] * irr_f * 0.05 * min(Dice - subD[i, k], 20.0)
             else:
                 mliqmax_k = 0.0
-            wirr_loc[k] = mliqmax_k - subW_old[i, k]
+            wirr_loc[k] = mliqmax_k - subW_old[k]
 
         # ------ Compute carrot (water-distribution profile) by percolation mode ------
         carrot_loc = np.zeros(nl)
@@ -409,9 +416,9 @@ def _percolation_kernel(
             excess = avail_W_loc - wlim_loc[n]
             if excess < 0.0:
                 excess = 0.0
-            new_subW_n = subW_old[i, n] + min(excess, wirr_loc[n])
+            new_subW_n = subW_old[n] + min(excess, wirr_loc[n])
             subW[i, n] = new_subW_n
-            avail_W_loc -= rp_n + (new_subW_n - subW_old[i, n])
+            avail_W_loc -= rp_n + (new_subW_n - subW_old[n])
             # Temperature and density update after percolating-water refreezing
             cpi_n = 152.2 + 7.122 * subT[i, n]
             subT[i, n] += Lm * rp_n / (subD[i, n] * cpi_n * subZ[i, n])

--- a/src/ebfm/core/LOOP_SNOW_kernels.py
+++ b/src/ebfm/core/LOOP_SNOW_kernels.py
@@ -66,8 +66,8 @@ def _compaction_kernel(
     gpsum, nl = subD.shape
     for i in prange(gpsum):
         # Snapshot this column's pre-compaction density and thickness (used for
-        # the layer-thickness update in section 3). Done per-thread here instead
-        # of copying the whole grid on the host before the launch.
+        # the layer-thickness update in section 3). Done per-thread instead
+        # of copying whole grid on the host before launch.
         subD_old = subD[i, :].copy()
         subZ_old = subZ[i, :].copy()
 
@@ -188,13 +188,7 @@ def _heat_conduction_prep_kernel(
     Produces the derived arrays (conductivity, heat capacity, interface
     conductivity-thickness products, squared inter-layer distances, update
     denominators and the CFL stability step) that _heat_conduction_kernel
-    consumes, directly from the resident subD/subZ/subT without a host-side
-    NumPy round-trip.
-
-    Every expression mirrors the NumPy precompute in
-    LOOP_SNOW.heat_conduction() operation-for-operation (including
-    parenthesization such as ``3.233e-6 * (d * d)`` and ``0.5 * (s * s)``) so
-    the result is bit-identical to the NumPy/host-precompute path.
+    needs, directly from subD/subZ/subT (without NumPy).
     """
     gpsum, nl = subD.shape
     for i in prange(gpsum):
@@ -342,7 +336,7 @@ def _percolation_kernel(
 
     for i in prange(gpsum):
         # Snapshot this column's pre-percolation water content, instead of
-        # copying the whole grid on the host before the launch.
+        # copying whole grid on the host before launch.
         subW_old = subW[i, :].copy()
 
         # ------ Refreezing and Irreducible Water Storage Limits ------


### PR DESCRIPTION
This MR introduced further optimizations on the host-side/CPU (non-kernel) parts of `LOOP_SNOW`. No physics changes.
It additionally serves as preparation for GPU offloading capability of EBFM.

@wardvp : You can check your actual production cases using this branch to test if your results remain unchanged. These performance optimizations should further speed-up your runtime up to 1.5x (see below).
It is important though to check whether your more realistic cases produce the same results.

### What changed

* `layer_merging_and_splitting`, `snowfall_and_deposition`, `melt_sublimation`: snapshot/copy only the rows/columns that are actually updated, instead of copying the full `(gpsum, nl)` grid on every step
* `compaction`, `percolation`: the `*_old` snapshots are taken per column inside the Numba kernels instead of on the host
* `heat_conduction`: the precompute (`kk`, `dz1/dz2`, `denom_*`, `dt_stab`) moved into a new `@njit` kernel `_heat_conduction_prep_kernel`. The NumPy path remains unchanged.
* Added `@profile` to the remaining `LOOP_SNOW` functions so `kernprof` covers all of them.
* The `performance` extra no longer installs `mpi4py` (it was never necessary here: Numba parallelises with threads inside a single process and does not need MPI).

## Improvement

On Levante (similar numbers on local copmuter) using the Elmer mesh example (gpsum 372k):

| | baseline | now | |
|---|---|---|---|
| `LOOP_SNOW` (numba) | 21.0 s | 7.0 s | **3.0x** |
| total runtime (numba) | 45.3 s | 31.7 s | **1.43x** |
| total runtime (numpy) | 135 s | 129 s | 1.05x |

The NumPy path gains little because its cost is the CFL heat solver and the percolation physics, which are untouched.

Results are bit-identical (`max |diff| = 0`, via `--dump-reference` + `tools/compare_snapshots.py`) for every commit, on both the matlab and Elmer mesh and with both backends.

# Author's Todos
- [x] I ran the [pre-commit hooks](https://github.com/EBFMorg/EBFM?tab=readme-ov-file#developer-notes) and fixed all issues
- [x] I added an entry under *develop* in the [CHANGELOG.md](https://github.com/EBFMorg/EBFM/blob/main/CHANGELOG.md) (may be skipped for minor changes not observable for the user)