### PR TITLE
Skip the shading look-up table when shading is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # develop
 
+* Fixed bug where the shading look-up table for MATLAB grids was pre-computed during initialization even when shading is disabled.  https://github.com/EBFMorg/EBFM/pull/155.
 * Fixed `phys["percolation"] = "uniform"` raising `TypeError` on the first timestep in `LOOP_SNOW.py` (only in NumPy path). `test_loop_snow_percolation.py` added.
 * EBFM now officially support and tests Python 3.14. https://github.com/EBFMorg/EBFM/pull/156
 * Fixed bug where resuming from a restart file (`--restart-init`) could lead to time step sizes equal to zero in `LOOP_SNOW.py`. Loading a restart file now asserts the restart variables to contain no missing values and converts them to plain `ndarray`. https://github.com/EBFMorg/EBFM/pull/154

--- a/src/ebfm/core/INIT.py
+++ b/src/ebfm/core/INIT.py
@@ -386,46 +386,48 @@ def init_grid(grid: GridDict, io, config: GridConfig):
         # -----------------------------------------------------------------------------------------------------
         # Pre-compute maximum grid elevation angle for various azimuth angles (needed for shading calculation)
         # -----------------------------------------------------------------------------------------------------
-        grid["shading_method"] = ShadingMethod.LUT  # shading based on look-up table (lut)
-        grid["nr_az_steps"] = 24  # number of azimuth angles (e.g. 24 = 1 per hour)
+        # Skip (expensive) pre-computation look-up table when shading is disabled.
+        if grid["has_shading"]:
+            grid["shading_method"] = ShadingMethod.LUT  # shading based on look-up table (lut)
+            grid["nr_az_steps"] = 24  # number of azimuth angles (e.g. 24 = 1 per hour)
 
-        # azimuth angles in radians from -pi to +pi with nr_az_steps number of steps
-        grid["az_array"] = np.arange(-np.pi, np.pi, 2 * np.pi / grid["nr_az_steps"])[::-1]
+            # azimuth angles in radians from -pi to +pi with nr_az_steps number of steps
+            grid["az_array"] = np.arange(-np.pi, np.pi, 2 * np.pi / grid["nr_az_steps"])[::-1]
 
-        xl, yl = grid["x_2D"].shape
+            xl, yl = grid["x_2D"].shape
 
-        # loop over the azimuth angles to determine gridded maximum grid angles per angle
-        grid["maxgridangle"] = np.zeros((grid["gpsum"], grid["nr_az_steps"]), dtype=np.float64)
-        for n in range(grid["nr_az_steps"]):
-            az = np.full(int(grid["gpsum"]), grid["az_array"][n], dtype=float)
+            # loop over the azimuth angles to determine gridded maximum grid angles per angle
+            grid["maxgridangle"] = np.zeros((grid["gpsum"], grid["nr_az_steps"]), dtype=np.float64)
+            for n in range(grid["nr_az_steps"]):
+                az = np.full(int(grid["gpsum"]), grid["az_array"][n], dtype=float)
 
-            # calculate step sizes (ddx, ddy) in x- and y-directions for all azimuth angles
-            ddx, ddy = calculate_step_sizes(az)
+                # calculate step sizes (ddx, ddy) in x- and y-directions for all azimuth angles
+                ddx, ddy = calculate_step_sizes(az)
 
-            # from every grid cell step in the direction of the azimuth until the grid end is reached
-            # and detect maximum grid angle along the path
-            i0, j0 = np.where(mask_2D == 1)
-            max_angle = np.full(grid["gpsum"], -np.inf, dtype=np.float64)
-            count = 1
-            active = np.ones(grid["gpsum"], dtype=bool)
-            while active.any():
-                j = np.round(j0 + ddx * count).astype(np.int64)  # column indices of target cells
-                i = np.round(i0 + ddy * count).astype(np.int64)  # row indices of target cells
+                # from every grid cell step in the direction of the azimuth until the grid end is reached
+                # and detect maximum grid angle along the path
+                i0, j0 = np.where(mask_2D == 1)
+                max_angle = np.full(grid["gpsum"], -np.inf, dtype=np.float64)
+                count = 1
+                active = np.ones(grid["gpsum"], dtype=bool)
+                while active.any():
+                    j = np.round(j0 + ddx * count).astype(np.int64)  # column indices of target cells
+                    i = np.round(i0 + ddy * count).astype(np.int64)  # row indices of target cells
 
-                inbound = (j >= 0) & (j < yl) & (i >= 0) & (i < xl) & active
-                if not inbound.any():  # stop when all walks have reached the domain edge
-                    break
+                    inbound = (j >= 0) & (j < yl) & (i >= 0) & (i < xl) & active
+                    if not inbound.any():  # stop when all walks have reached the domain edge
+                        break
 
-                grid_angle = compute_grid_angle(grid, i, j, inbound)  # calculate grid angle from start to target
+                    grid_angle = compute_grid_angle(grid, i, j, inbound)  # calculate grid angle from start to target
 
-                max_angle[inbound] = np.maximum(max_angle[inbound], grid_angle)  # update max grid angle when needed
+                    max_angle[inbound] = np.maximum(max_angle[inbound], grid_angle)  # update max grid angle if needed
 
-                active &= (j >= 0) & (j < yl) & (i >= 0) & (i < xl)  # continue walk until domain edge is reached
+                    active &= (j >= 0) & (j < yl) & (i >= 0) & (i < xl)  # continue walk until domain edge is reached
 
-                count += 1
+                    count += 1
 
-            # fill lookup table with maximum grid angles for all cells (dimension 1) and azimuth angle (dimension 2)
-            grid["maxgridangle"][:, n] = max_angle
+                # fill lookup table with maximum grid angles for all cells (dim 1) and azimuth angle (dim 2)
+                grid["maxgridangle"][:, n] = max_angle
 
         # TODO introduce object for MATLAB grid similar to the Mesh object for Elmer grids and store in grid["mesh"].
     else:

--- a/src/ebfm/core/INIT.py
+++ b/src/ebfm/core/INIT.py
@@ -386,54 +386,70 @@ def init_grid(grid: GridDict, io, config: GridConfig):
         # -----------------------------------------------------------------------------------------------------
         # Pre-compute maximum grid elevation angle for various azimuth angles (needed for shading calculation)
         # -----------------------------------------------------------------------------------------------------
-        # Skip (expensive) pre-computation look-up table when shading is disabled.
+        # Skip the (expensive) look-up table when shading is disabled.
         if grid["has_shading"]:
-            grid["shading_method"] = ShadingMethod.LUT  # shading based on look-up table (lut)
-            grid["nr_az_steps"] = 24  # number of azimuth angles (e.g. 24 = 1 per hour)
-
-            # azimuth angles in radians from -pi to +pi with nr_az_steps number of steps
-            grid["az_array"] = np.arange(-np.pi, np.pi, 2 * np.pi / grid["nr_az_steps"])[::-1]
-
-            xl, yl = grid["x_2D"].shape
-
-            # loop over the azimuth angles to determine gridded maximum grid angles per angle
-            grid["maxgridangle"] = np.zeros((grid["gpsum"], grid["nr_az_steps"]), dtype=np.float64)
-            for n in range(grid["nr_az_steps"]):
-                az = np.full(int(grid["gpsum"]), grid["az_array"][n], dtype=float)
-
-                # calculate step sizes (ddx, ddy) in x- and y-directions for all azimuth angles
-                ddx, ddy = calculate_step_sizes(az)
-
-                # from every grid cell step in the direction of the azimuth until the grid end is reached
-                # and detect maximum grid angle along the path
-                i0, j0 = np.where(mask_2D == 1)
-                max_angle = np.full(grid["gpsum"], -np.inf, dtype=np.float64)
-                count = 1
-                active = np.ones(grid["gpsum"], dtype=bool)
-                while active.any():
-                    j = np.round(j0 + ddx * count).astype(np.int64)  # column indices of target cells
-                    i = np.round(i0 + ddy * count).astype(np.int64)  # row indices of target cells
-
-                    inbound = (j >= 0) & (j < yl) & (i >= 0) & (i < xl) & active
-                    if not inbound.any():  # stop when all walks have reached the domain edge
-                        break
-
-                    grid_angle = compute_grid_angle(grid, i, j, inbound)  # calculate grid angle from start to target
-
-                    max_angle[inbound] = np.maximum(max_angle[inbound], grid_angle)  # update max grid angle if needed
-
-                    active &= (j >= 0) & (j < yl) & (i >= 0) & (i < xl)  # continue walk until domain edge is reached
-
-                    count += 1
-
-                # fill lookup table with maximum grid angles for all cells (dim 1) and azimuth angle (dim 2)
-                grid["maxgridangle"][:, n] = max_angle
+            _precompute_shading_matlab(grid, mask_2D)
 
         # TODO introduce object for MATLAB grid similar to the Mesh object for Elmer grids and store in grid["mesh"].
     else:
         raise ValueError(f"Unsupported grid input type {config.grid_type} specified in configuration.")
 
     return grid
+
+
+def _precompute_shading_matlab(grid: GridDict, mask_2D) -> None:
+    """Pre-compute the shading look-up table of a MATLAB grid.
+
+    For every azimuth angle, walk outwards from each glacier cell until the domain edge is
+    reached and record the largest grid elevation angle seen along the path. The resulting
+    table `grid["maxgridangle"]` of shape (gpsum, nr_az_steps) lets the time loop decide
+    whether a cell is shaded without repeating the walk. This is the expensive part of grid
+    initialization, so it is only called when shading is enabled.
+
+    @param[in,out] grid Grid dictionary, updated with `shading_method`, `nr_az_steps`,
+                        `az_array` and `maxgridangle`.
+    @param[in] mask_2D 2-D glacier mask, 1 for glacier cells.
+    """
+    grid["shading_method"] = ShadingMethod.LUT  # shading based on look-up table (lut)
+    grid["nr_az_steps"] = 24  # number of azimuth angles (e.g. 24 = 1 per hour)
+
+    # azimuth angles in radians from -pi to +pi with nr_az_steps number of steps
+    grid["az_array"] = np.arange(-np.pi, np.pi, 2 * np.pi / grid["nr_az_steps"])[::-1]
+
+    xl, yl = grid["x_2D"].shape
+
+    # loop over the azimuth angles to determine gridded maximum grid angles per angle
+    grid["maxgridangle"] = np.zeros((grid["gpsum"], grid["nr_az_steps"]), dtype=np.float64)
+    for n in range(grid["nr_az_steps"]):
+        az = np.full(int(grid["gpsum"]), grid["az_array"][n], dtype=float)
+
+        # calculate step sizes (ddx, ddy) in x- and y-directions for all azimuth angles
+        ddx, ddy = calculate_step_sizes(az)
+
+        # from every grid cell step in the direction of the azimuth until the grid end is reached
+        # and detect maximum grid angle along the path
+        i0, j0 = np.where(mask_2D == 1)
+        max_angle = np.full(grid["gpsum"], -np.inf, dtype=np.float64)
+        count = 1
+        active = np.ones(grid["gpsum"], dtype=bool)
+        while active.any():
+            j = np.round(j0 + ddx * count).astype(np.int64)  # column indices of target cells
+            i = np.round(i0 + ddy * count).astype(np.int64)  # row indices of target cells
+
+            inbound = (j >= 0) & (j < yl) & (i >= 0) & (i < xl) & active
+            if not inbound.any():  # stop when all walks have reached the domain edge
+                break
+
+            grid_angle = compute_grid_angle(grid, i, j, inbound)  # calculate grid angle from start to target
+
+            max_angle[inbound] = np.maximum(max_angle[inbound], grid_angle)  # update max grid angle if needed
+
+            active &= (j >= 0) & (j < yl) & (i >= 0) & (i < xl)  # continue walk until domain edge is reached
+
+            count += 1
+
+        # fill lookup table with maximum grid angles for all cells (dim 1) and azimuth angle (dim 2)
+        grid["maxgridangle"][:, n] = max_angle
 
 
 def compute_grid_angle(grid: GridDict, i, j, inbound) -> float:

--- a/tests/core/test_init.py
+++ b/tests/core/test_init.py
@@ -7,17 +7,24 @@
 import unittest
 import tempfile
 from pathlib import Path
+from unittest import mock
 
 from datetime import datetime, timezone
 
 import numpy as np
 from netCDF4 import Dataset
 
-from ebfm.core.INIT import init_initial_conditions
+from ebfm.core import INIT
+from ebfm.core.INIT import init_config, init_grid, init_initial_conditions
 from ebfm.core.FINAL_create_restart_file import main as write_restart_file
+from ebfm.core.cli import parse_cli_args
+from ebfm.core.config.grid import GridConfig
+from ebfm.core.config.time import TimeConfig
 
 GPSUM = 5
 NL = 4
+
+_MATLAB_MESH = Path(__file__).parents[2] / "examples" / "dem_and_mask.mat"
 
 
 def _build_out_dict() -> dict:
@@ -109,6 +116,44 @@ class TestInitFromRestartFile(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             init_initial_conditions(C, grid, io, time, init_with_restart_file=True)
+
+
+class TestMatlabShadingLookupTable(unittest.TestCase):
+    """The shading look-up table must only be pre-computed when shading is enabled.
+
+    Building it is by far the most expensive part of grid initialization (ca. 25 s for
+    examples/dem_and_mask.mat), so the test never lets it run: the disabled case skips
+    it by design and the enabled case patches the helper and only checks that it is
+    called. What the look-up table contains is not affected by this.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def _init_grid(self, shading_flag):
+        args = parse_cli_args(["--matlab-mesh", str(_MATLAB_MESH), shading_flag])
+        grid_config = GridConfig(args)
+        grid, io, _ = init_config(TimeConfig(args), grid_config, Path(self.tmpdir.name), False)
+        return init_grid(grid, io, grid_config)
+
+    def test_shading_disabled_skips_the_lookup_table(self):
+        grid = self._init_grid("--no-shading")
+
+        self.assertFalse(grid["has_shading"])
+        for key in ("maxgridangle", "az_array", "nr_az_steps", "shading_method"):
+            self.assertNotIn(key, grid, f"{key} must not be created when shading is disabled")
+
+    def test_shading_enabled_precomputes_the_lookup_table(self):
+        # Swap the helper for a recorder while init_grid runs: this checks that the
+        # call happens, without building the (ca. 25 s) look-up table itself.
+        with mock.patch.object(INIT, "_precompute_shading_matlab") as precompute:
+            grid = self._init_grid("--shading")
+
+        self.assertTrue(grid["has_shading"])
+        precompute.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For MATLAB grids, `init_grid` always pre-computed the maximum-grid-angle look-up table (`grid["maxgridangle"]`), even when shading was switched off.

That table is only read by the shading branch of `LOOP_EBM_insolation`, which is itself guarded by `grid["has_shading"]`. With shading disabled the whole loop ran at startup and the result was discarded.

The fix guards the pre-computation with `grid["has_shading"]`. With shading enabled nothing changes.

On the Svalbard example grid (`examples/dem_and_mask.mat`, 37993 glacier cells) the costs were:

shading | init_grid
-- | --
off (before) | 8.2 s
off (after) | 0.07 s
on | 8.2 s, unchanged

The cost of course scales with cells × domain diameter, so the saving is larger on bigger grids.

# Author's Todos

- [X] I ran the [pre-commit hooks](https://github.com/EBFMorg/EBFM?tab=readme-ov-file#developer-notes) and fixed all issues
- [X] I added an entry under *develop* in the [CHANGELOG.md](https://github.com/EBFMorg/EBFM/blob/main/CHANGELOG.md) (may be skipped for minor changes not observable for the user)
