### PR TITLE
Add Python 3.14 to the tested versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v6
@@ -48,7 +48,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13"]  # only run MPI tests for latest Python version
+        # Deliberately kept at 3.13 and not raised to the latest version: MPI tests only run for
+        # a single Python version and 3.13 is the most commonly used one.
+        python-version: ["3.13"]
 
     steps:
     - uses: actions/checkout@v6
@@ -77,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # develop
 
+* Add Python 3.14 to the tested versions (unit and example tests). https://github.com/EBFMorg/EBFM/pull/156
 * Fixed bug where resuming from a restart file (`--restart-init`) could lead to time step sizes equal to zero in `LOOP_SNOW.py`. Loading a restart file now asserts the restart variables to contain no missing values and converts them to plain `ndarray`. https://github.com/EBFMorg/EBFM/pull/154
 * Fixed bug in icon_to_atmo.py to convert pr_snow units to mwe per timestep (rather than using kg m-2 s-1). https://github.com/EBFMorg/EBFM/pull/149
 * Add general interface for definition of fallback values if a coupled component does not provide expected data for individual fields. https://github.com/EBFMorg/EBFM/pull/146.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # develop
 
-* Add Python 3.14 to the tested versions (unit and example tests). https://github.com/EBFMorg/EBFM/pull/156
+* EBFM now officially support and tests Python 3.14. https://github.com/EBFMorg/EBFM/pull/156
 * Fixed bug where resuming from a restart file (`--restart-init`) could lead to time step sizes equal to zero in `LOOP_SNOW.py`. Loading a restart file now asserts the restart variables to contain no missing values and converts them to plain `ndarray`. https://github.com/EBFMorg/EBFM/pull/154
 * Fixed bug in icon_to_atmo.py to convert pr_snow units to mwe per timestep (rather than using kg m-2 s-1). https://github.com/EBFMorg/EBFM/pull/149
 * Add general interface for definition of fallback values if a coupled component does not provide expected data for individual fields. https://github.com/EBFMorg/EBFM/pull/146.

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 
 [tox]
 min_version = 4.0
-envlist = py{310,311,312,313}
+envlist = py{310,311,312,313,314}
 
 [testenv]
 extras =
@@ -60,6 +60,7 @@ commands =
 [gh-actions]
 python =
     3.10: py310 # Python Version used on Levante
-    3.11: py311
+    3.11: py311 # Python Version used on LUMI
     3.12: py312 # Development version used on Ubuntu 24.04
     3.13: py313 # Development version used on Ubuntu 25.04
+    3.14: py314 # Version provided by miniforge on Levante, used in TerraDT test case


### PR DESCRIPTION
Python 3.14 is the version provided by a miniforge on Levante and used by the TerraDT test case, but it was not covered by the CI here yet. This adds it to the `tox envlist`, the `gh-actions mapping` and the `unit-test` and `example-tests` matrices.

The MPI unit-test job stays on 3.13. It deliberately runs for a single version only and at the moment 3.13 is the most commonly used one. Also documents 3.11 as the version used on LUMI.

- [x] I ran the [pre-commit hooks](https://github.com/EBFMorg/EBFM?tab=readme-ov-file#developer-notes) and fixed all issues
- [x] I added an entry under *develop* in the [CHANGELOG.md](https://github.com/EBFMorg/EBFM/blob/main/CHANGELOG.md) (may be skipped for minor changes not observable for the user)
