### PR TITLE
Add GPU offload backend (in LOOP_SNOW)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,32 @@ jobs:
     - name: Run unit tests with MPI
       run: tox -e unit-mpi
 
+  gpu-simulator-test:
+    name: GPU backend vs NumPy (CUDA simulator, Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.13"]  # kernel logic is Python-version independent, one run is enough
+
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install tox
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox
+
+    - name: Run the GPU kernels on the CUDA simulator
+      run: tox -e gpu-sim
+
   example-tests:
     name: Example tests (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # develop
 
-* Introduce `--with-gpu` to offload the kernels compaction, heat conduction, percolation to a GPU via `numba.cuda` (NVIDIA) or `numba.hip` (AMD), with `--gpu-vendor {auto,nvidia,amd}` to select/guard the vendor. Mutually exclusive with `--with-numba`. Install via `pip install ebfm[gpu]`.
+* Introduced `--with-gpu` to offload the kernels compaction, heat conduction, percolation to a GPU via `numba.cuda` (NVIDIA) or `numba.hip` (AMD), with `--gpu-vendor {auto,nvidia,amd}` to select/guard the vendor. Mutually exclusive with `--with-numba`. Install via `pip install ebfm[gpu]`.
+* Added `tests/core/test_loop_snow_gpu.py`: runs the snow model on the NumPy and GPU backends from an identical state and requires agreement to `atol=1e-12, rtol=1e-9`. Uses numba's CUDA simulator, so it needs no GPU.
 * Further optimizations in CPU/host-side code in `LOOP_SNOW.py`: fewer full-grid copies, heat conduction precompute moved into Numba kernel. https://github.com/EBFMorg/EBFM/pull/147.
 * The `performance` extra no longer installs `mpi4py`: Numba parallelises with threads inside a single process and does not require MPI. Use `EBFM[performance,mpi]` to combine both. https://github.com/EBFMorg/EBFM/pull/147.
 * Fixed bug where the shading look-up table for MATLAB grids was pre-computed during initialization even when shading is disabled.  https://github.com/EBFMorg/EBFM/pull/155.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # develop
 
+* Introduce `--with-gpu` to offload the kernels compaction, heat conduction, percolation to a GPU via `numba.cuda` (NVIDIA) or `numba.hip` (AMD), with `--gpu-vendor {auto,nvidia,amd}` to select/guard the vendor. Mutually exclusive with `--with-numba`. Install via `pip install ebfm[gpu]`.
 * Further optimizations in CPU/host-side code in `LOOP_SNOW.py`: fewer full-grid copies, heat conduction precompute moved into Numba kernel. https://github.com/EBFMorg/EBFM/pull/147.
 * The `performance` extra no longer installs `mpi4py`: Numba parallelises with threads inside a single process and does not require MPI. Use `EBFM[performance,mpi]` to combine both. https://github.com/EBFMorg/EBFM/pull/147.
 * Fixed bug where the shading look-up table for MATLAB grids was pre-computed during initialization even when shading is disabled.  https://github.com/EBFMorg/EBFM/pull/155.

--- a/README.md
+++ b/README.md
@@ -274,6 +274,12 @@ EBFM now includes several performance improvements and supports several options 
   python -c "from numba import cuda; print(cuda.is_available())"
   ```
 
+  At startup `--with-gpu` reports which stack and device it found, so you can check it went to the GPU you expected:
+
+  ```
+  [GPU] backend enabled (nvidia). Device: NVIDIA A100-SXM4-80GB  free=79.15 GiB  total=79.15 GiB
+  ```
+
 
 #### Timing Your Run
 

--- a/README.md
+++ b/README.md
@@ -257,14 +257,14 @@ EBFM now includes several performance improvements and supports several options 
 
 - GPU offloading:
 
-  Install the GPU dependencies and use the `--with-gpu` flag to offload the compaction, heat conduction and percolation kernels to a GPU:
+  Install the GPU dependencies and use the `--with-gpu` flag to offload kernels from `LOOP_SNOW.py` to a GPU:
 
   ```sh
   pip install -e .[gpu]
   ebfm --matlab-mesh examples/dem_and_mask.mat --with-gpu
   ```
 
-  The same kernels run on NVIDIA (via `numba.cuda`) and on AMD (via `numba.hip`). The vendor is detected automatically; use `--gpu-vendor {auto,nvidia,amd}` to select or guard it explicitly. `--with-gpu` and `--with-numba` are mutually exclusive.
+  The same kernels run on NVIDIA (via `numba.cuda`) and on AMD (via `numba.hip`). The vendor is detected automatically. You can use `--gpu-vendor {auto,nvidia,amd}` to select or guard it explicitly. `--with-gpu` and `--with-numba` are mutually exclusive.
 
   Note: on a cluster you usually have to load a CUDA/ROCm toolkit and point `CUDA_HOME` at it, otherwise Numba cannot compile the kernels even though the GPU itself is visible. See [CUDA runtime not found](#numba-does-not-find-the-cuda-runtime-cudais_available-is-false) in the troubleshooting section.
 

--- a/README.md
+++ b/README.md
@@ -255,6 +255,25 @@ EBFM now includes several performance improvements and supports several options 
 
   Note: If you use more than one thread, you must specify `--numba-threads`. In practice, 2 threads have shown the best performance so far, but optimal settings depend on your hardware and problem size. Feel free to experiment.
 
+- GPU offloading:
+
+  Install the GPU dependencies and use the `--with-gpu` flag to offload the compaction, heat conduction and percolation kernels to a GPU:
+
+  ```sh
+  pip install -e .[gpu]
+  ebfm --matlab-mesh examples/dem_and_mask.mat --with-gpu
+  ```
+
+  The same kernels run on NVIDIA (via `numba.cuda`) and on AMD (via `numba.hip`). The vendor is detected automatically; use `--gpu-vendor {auto,nvidia,amd}` to select or guard it explicitly. `--with-gpu` and `--with-numba` are mutually exclusive.
+
+  Note: on a cluster you usually have to load a CUDA/ROCm toolkit and point `CUDA_HOME` at it, otherwise Numba cannot compile the kernels even though the GPU itself is visible. See [CUDA runtime not found](#numba-does-not-find-the-cuda-runtime-cudais_available-is-false) in the troubleshooting section.
+
+  Before a long run you can verify the setup with:
+
+  ```sh
+  python -c "from numba import cuda; print(cuda.is_available())"
+  ```
+
 
 #### Timing Your Run
 
@@ -393,6 +412,19 @@ pytest -v tests/
 *Problem:* `./icon_dummy.x: error while loading shared libraries: libyaxt_c.so.1: cannot open shared object file: No such file or directory`
 
 *Solution:* `export LD_LIBRARY_PATH='$YAXT_INSTALL_DIR/lib/'
+
+### Numba does not find the CUDA runtime (`cuda.is_available()` is `False`)
+
+*Problem:* `--with-gpu` fails, or `python -c "from numba import cuda; print(cuda.is_available())"` prints `False`, even though the GPU is visible. Note that `cuda.detect()` and `nvidia-smi` can still report the device correctly: they only need the CUDA *driver*, while Numba additionally needs the CUDA *runtime* (`libnvvm`, `libcudart`) to compile kernels.
+
+*Solution:* Point `CUDA_HOME` at a CUDA toolkit installation and add its libraries to `LD_LIBRARY_PATH`. On Levante, for example:
+
+```sh
+export CUDA_HOME=/sw/spack-levante/nvhpc-22.5-v4oky3/Linux_x86_64/22.5/cuda/11.7
+export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$LD_LIBRARY_PATH
+```
+
+Afterwards `cuda.is_available()` should print `True`.
 
 ### `#include <proj.h>` not found when building the Elmer dummy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,12 +43,12 @@ performance = [
 ]
 
 gpu = [
-    # GPU offload runs in a single process and does not require MPI. Combine
-    # with the mpi extra (EBFM[gpu,mpi]) to run MPI ranks with a GPU per rank.
+    # GPU offload runs in a single process and does not require MPI.
     # NVIDIA: numba >= 0.62 bundles numba.cuda (verified with numba 0.66 on A100).
     # AMD (MI300A / gfx942): GPU offload runs the same numba.cuda kernels via
     # numba-hip's pose_as_cuda(). numba-hip requires numba >= 0.58, < 0.62 and a
-    # ROCm environment, so install it separately rather than through here.
+    # ROCm environment (better to install separately rather than through here).
+    # (Status as of July 2026)
     "numba >= 0.62",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,16 @@ performance = [
     "numba >= 0.59",
 ]
 
+gpu = [
+    # GPU offload runs in a single process and does not require MPI. Combine
+    # with the mpi extra (EBFM[gpu,mpi]) to run MPI ranks with a GPU per rank.
+    # NVIDIA: numba >= 0.62 bundles numba.cuda (verified with numba 0.66 on A100).
+    # AMD (MI300A / gfx942): GPU offload runs the same numba.cuda kernels via
+    # numba-hip's pose_as_cuda(). numba-hip requires numba >= 0.58, < 0.62 and a
+    # ROCm environment, so install it separately rather than through here.
+    "numba >= 0.62",
+]
+
 [project.scripts]
 ebfm = "ebfm.main:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,12 +43,17 @@ performance = [
 ]
 
 gpu = [
-    # GPU offload runs in a single process and does not require MPI.
-    # NVIDIA: numba >= 0.62 bundles numba.cuda (verified with numba 0.66 on A100).
-    # AMD (MI300A / gfx942): GPU offload runs the same numba.cuda kernels via
-    # numba-hip's pose_as_cuda(). numba-hip requires numba >= 0.58, < 0.62 and a
-    # ROCm environment (better to install separately rather than through here).
-    # (Status as of July 2026)
+    # GPU offload runs in a single process and does not require MPI. Combine with
+    # the mpi extra (EBFM[gpu,mpi]) to run one MPI rank per GPU.
+    #
+    # NVIDIA: numba ships numba.cuda itself from 0.62 on, so no extra package is
+    # needed.
+    #
+    # AMD (MI300A / gfx942): the same numba.cuda kernels run through numba-hip's
+    # pose_as_cuda(). numba-hip pins numba to >= 0.58, < 0.62 (incompatible with
+    # the lower bound here, so it cannot be installed through the extra in EBFM.
+    # Install it into a ROCm environment separately. Status as of April 2026,
+    # not re-checked since).
     "numba >= 0.62",
 ]
 

--- a/src/ebfm/core/LOOP_SNOW.py
+++ b/src/ebfm/core/LOOP_SNOW.py
@@ -14,9 +14,8 @@ from .LOOP_SNOW_kernels import (
     _percolation_kernel,
 )
 
-# SnowDeviceState is imported lazily inside the GPU branch of main() so that
-# NumPy/Numba-only users never trigger the numba.cuda / numba.hip import (and
-# its import-time vendor detection) in LOOP_SNOW_gpu_kernels.
+# SnowDeviceState is imported lazily inside the GPU branch. Using NumPy/Numba
+# never pulls in GPU dependencies
 
 # line_profiler support: `profile` is injected as a builtin by kernprof.
 # When running normally, fall back to a no-op so the decorator stays in place.
@@ -279,7 +278,7 @@ def main(C, OUT, IN, dt: float, grid, phys):
             else:
                 OUT[_key].fill(0.0)
 
-        # runoff_irr is written by the kernel; ensure it exists before it reads.
+        # runoff_irr is written by the kernel. Ensure it exists before it reads.
         _gshape = (gpsum,)
         if "runoff_irr" not in OUT or OUT["runoff_irr"].shape != _gshape:
             OUT["runoff_irr"] = np.zeros(_gshape)
@@ -292,7 +291,7 @@ def main(C, OUT, IN, dt: float, grid, phys):
                 raise ValueError(f"_compaction_kernel: unknown snow_compaction={phys['snow_compaction']!r}")
             _tau_drift = 48 * 2 * SECONDS_PER_HOUR
             if gpu is not None:
-                # GPU: kernel launched on the resident device arrays; the
+                # GPU: kernel launched on the resident device arrays. The
                 # pre-compaction subD/subZ snapshot is taken on-device.
                 gpu.compaction(
                     OUT["Dens_destr_metam"],
@@ -480,7 +479,7 @@ def main(C, OUT, IN, dt: float, grid, phys):
         """
         if gpu is not None:
             # GPU: the prep / solve / boundary-clip kernels run on the resident
-            # device arrays, so the host precompute and post-clip below are done
+            # device arrays. Host precompute and post-clip below are done
             # on-device (subK / subCeff are returned in download()).
             gpu.heat_conduction(dt, C)
             return _SUCCESS
@@ -650,7 +649,7 @@ def main(C, OUT, IN, dt: float, grid, phys):
                 0.0,
             )
             if gpu is not None:
-                # GPU: kernel launched on the resident device arrays; the
+                # GPU: kernel launched on the resident device arrays. The
                 # post-heat subW snapshot is taken on-device.
                 gpu.percolation(_avail_W, C, _p_mode, dt)
                 return _SUCCESS
@@ -1018,10 +1017,8 @@ def main(C, OUT, IN, dt: float, grid, phys):
         # Resident-state core: subT/subD/subZ/subW/subS stay on the device
         # across compaction -> heat conduction -> percolation. The subsurface
         # state is uploaded once here and downloaded once after percolation,
-        # instead of round-tripping in each sub-step. The three functions run
-        # their usual host-side glue and dispatch their kernel launches to the
-        # device state; results match the NumPy/Numba paths.
-        # Imported here (not at module top) so only GPU runs pull in numba.cuda.
+        # instead of round-tripping in each sub-step.
+        # Imported here so only GPU runs pull in numba.cuda.
         from .LOOP_SNOW_gpu_kernels import SnowDeviceState
 
         gpu_state = SnowDeviceState(

--- a/src/ebfm/core/LOOP_SNOW.py
+++ b/src/ebfm/core/LOOP_SNOW.py
@@ -14,6 +14,10 @@ from .LOOP_SNOW_kernels import (
     _percolation_kernel,
 )
 
+# SnowDeviceState is imported lazily inside the GPU branch of main() so that
+# NumPy/Numba-only users never trigger the numba.cuda / numba.hip import (and
+# its import-time vendor detection) in LOOP_SNOW_gpu_kernels.
+
 # line_profiler support: `profile` is injected as a builtin by kernprof.
 # When running normally, fall back to a no-op so the decorator stays in place.
 try:
@@ -255,7 +259,7 @@ def main(C, OUT, IN, dt: float, grid, phys):
         return _SUCCESS
 
     @profile
-    def compaction():
+    def compaction(gpu=None):
         """
         Calculate snow and firn compaction and update density and layer thickness
         """
@@ -275,17 +279,34 @@ def main(C, OUT, IN, dt: float, grid, phys):
             else:
                 OUT[_key].fill(0.0)
 
-        # runoff_irr is written by kernel function
-        # ensure it exists before the Numba kernel reads it
+        # runoff_irr is written by the kernel; ensure it exists before it reads.
         _gshape = (gpsum,)
         if "runoff_irr" not in OUT or OUT["runoff_irr"].shape != _gshape:
             OUT["runoff_irr"] = np.zeros(_gshape)
 
-        # Numba parallel path:
-        if get_backend() == ComputeBackend.NUMBA:
+        # Numba / GPU kernel path:
+        backend = get_backend()
+        if backend in (ComputeBackend.NUMBA, ComputeBackend.GPU):
             _mode = {"firn_only": 0, "firn+snow": 1}.get(phys["snow_compaction"], -1)
             if _mode < 0:
                 raise ValueError(f"_compaction_kernel: unknown snow_compaction={phys['snow_compaction']!r}")
+            _tau_drift = 48 * 2 * SECONDS_PER_HOUR
+            if gpu is not None:
+                # GPU: kernel launched on the resident device arrays; the
+                # pre-compaction subD/subZ snapshot is taken on-device.
+                gpu.compaction(
+                    OUT["Dens_destr_metam"],
+                    OUT["Dens_overb_pres"],
+                    OUT["Dens_drift"],
+                    dt_yearfrac,
+                    dt_seconds,
+                    dt,
+                    C,
+                    _tau_drift,
+                    _mode,
+                )
+                return _SUCCESS
+
             _compaction_kernel(
                 OUT["subD"],
                 OUT["subZ"],
@@ -313,7 +334,7 @@ def main(C, OUT, IN, dt: float, grid, phys):
                 C["Ec"],
                 C["Eg"],
                 C["dayseconds"],
-                48 * 2 * SECONDS_PER_HOUR,
+                _tau_drift,
                 _mode,
             )
         else:
@@ -453,10 +474,17 @@ def main(C, OUT, IN, dt: float, grid, phys):
         return _SUCCESS
 
     @profile
-    def heat_conduction():
+    def heat_conduction(gpu=None):
         """
         Calculate heat diffusion and update temperatures
         """
+        if gpu is not None:
+            # GPU: the prep / solve / boundary-clip kernels run on the resident
+            # device arrays, so the host precompute and post-clip below are done
+            # on-device (subK / subCeff are returned in download()).
+            gpu.heat_conduction(dt, C)
+            return _SUCCESS
+
         # ------ Heat Conduction Loop ------
         if get_backend() == ComputeBackend.NUMBA:
             # Numba parallel path
@@ -605,14 +633,15 @@ def main(C, OUT, IN, dt: float, grid, phys):
         return _SUCCESS
 
     @profile
-    def percolation_refreezing_and_storage():
+    def percolation_refreezing_and_storage(gpu=None):
         #########################################################
         # Percolation, refreezing and irreducible water storage
         #########################################################
         gpsum, nl = OUT["subT"].shape
 
-        if get_backend() == ComputeBackend.NUMBA:
-            # Numba parallel path:
+        backend = get_backend()
+        if backend in (ComputeBackend.NUMBA, ComputeBackend.GPU):
+            # Numba / GPU kernel path:
             _p_mode = {"bucket": 0, "normal": 1, "linear": 2, "uniform": 3}.get(phys["percolation"], -1)
             if _p_mode < 0:
                 raise ValueError(f"_percolation_kernel: unknown percolation={phys['percolation']!r}")
@@ -620,6 +649,12 @@ def main(C, OUT, IN, dt: float, grid, phys):
                 OUT["melt"] * 1e3 + IN["rain"] * 1e3 + (OUT["moist_condensation"] - OUT["moist_evaporation"]) * 1e3,
                 0.0,
             )
+            if gpu is not None:
+                # GPU: kernel launched on the resident device arrays; the
+                # post-heat subW snapshot is taken on-device.
+                gpu.percolation(_avail_W, C, _p_mode, dt)
+                return _SUCCESS
+
             # Ensure persistent arrays are allocated
             _rp_shape = OUT["subZ"].shape
             if "_perc_RP" not in OUT or OUT["_perc_RP"].shape != _rp_shape:
@@ -979,9 +1014,38 @@ def main(C, OUT, IN, dt: float, grid, phys):
 
     snowfall_and_deposition()
     melt_sublimation()
-    compaction()
-    heat_conduction()
-    percolation_refreezing_and_storage()
+    if get_backend() == ComputeBackend.GPU:
+        # Resident-state core: subT/subD/subZ/subW/subS stay on the device
+        # across compaction -> heat conduction -> percolation. The subsurface
+        # state is uploaded once here and downloaded once after percolation,
+        # instead of round-tripping in each sub-step. The three functions run
+        # their usual host-side glue and dispatch their kernel launches to the
+        # device state; results match the NumPy/Numba paths.
+        # Imported here (not at module top) so only GPU runs pull in numba.cuda.
+        from .LOOP_SNOW_gpu_kernels import SnowDeviceState
+
+        gpu_state = SnowDeviceState(
+            OUT["subT"],
+            OUT["subD"],
+            OUT["subZ"],
+            OUT["subW"],
+            OUT["subS"],
+            OUT["subTmean"],
+            OUT["surfH"],
+            IN["logyearsnow"],
+            IN["yearsnow"],
+            IN["WS"],
+            OUT["Tsurf"],
+            OUT["sumWinit"],
+        )
+        compaction(gpu_state)
+        heat_conduction(gpu_state)
+        percolation_refreezing_and_storage(gpu_state)
+        gpu_state.download(OUT)
+    else:
+        compaction()
+        heat_conduction()
+        percolation_refreezing_and_storage()
     layer_merging_and_splitting()
     runoff()
     OUT["T_ice"] = OUT["subT"][:, -1]

--- a/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
+++ b/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
@@ -9,7 +9,7 @@ Availability: numba.cuda kernels for compaction, heat conduction and
 percolation, offloaded to a GPU when the GPU backend is active (--with-gpu).
 
 The same kernels run on both vendors:
-- NVIDIA via stock numba.cuda,
+- NVIDIA via numba.cuda,
 - AMD via numba.hip.pose_as_cuda() (see compute_backend.py).
 
 Each ``_*_kernel_gpu`` is the CUDA-thread equivalent of the corresponding
@@ -57,7 +57,7 @@ def _blocks(gpsum: int) -> int:
 # via a separate overload mechanism and is unaffected.
 #
 # @cuda.jit(device=True) functions are the canonical numba solution: they
-# are compiled once for the device, inlined at every call site, and work
+# are compiled once for the device, inlined at every call site and work
 # on all supported numba versions and Python versions.
 #
 # When the GPU stack is absent (_CudaStub from compute_backend), the

--- a/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
+++ b/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
@@ -52,19 +52,17 @@ def _blocks(gpsum: int) -> int:
 # ---------------------------------------------------------------------------
 # Device helper functions
 #
-# Python's built-in max(), min(), abs() cannot be reliably used inside
-# @cuda.jit kernels across all numba/Python versions.  In Python 3.12+
-# (and especially 3.14) numba's CUDA type-inference maps them to a
-# single-argument overload, raising "2 argument types given, but function
-# takes 1 arguments" at JIT-compile time.  The CPU @njit path handles them
-# via a separate overload mechanism and is unaffected.
+# These exist because the built-ins are not usable here: inside @cuda.jit,
+# numba's CUDA type inference resolves the two-argument max()/min() to a
+# single-argument overload and fails to compile with "2 argument types given,
+# but function takes 1 arguments" (Python 3.12+).
+# The CPU @njit kernels in LOOP_SNOW_kernels.py resolve them through a different
+# overload mechanism, which is why they call max()/min()/abs() directly.
 #
-# @cuda.jit(device=True) functions are the canonical numba solution: they
-# are compiled once for the device, inlined at every call site and work
-# on all supported numba versions and Python versions.
-#
-# When the GPU stack is absent (_CudaStub from compute_backend), the
-# decorator is a no-op, so the functions stay importable as plain Python.
+# @cuda.jit(device=True) is numba's own answer to this: compiled once for the
+# device and inlined at every call site, so there is no call overhead. When no
+# GPU stack is installed, `cuda` is the _CudaStub from compute_backend and the
+# decorator is a no-op, so these stay importable as plain Python.
 # ---------------------------------------------------------------------------
 
 
@@ -93,7 +91,7 @@ def _fabs(x):
 
 @cuda.jit
 def _gpu_probe_kernel(arr):
-    """Trivial kernel used only by gpu_offload_smoke_test().
+    """Trivial kernel used only by probe_gpu_device().
 
     Multiplies every element of ``arr`` by 2 to verify a GPU round-trip.
     """
@@ -837,15 +835,21 @@ class SnowDeviceState:
 
 
 # ===========================================================================
-# Smoke test
+# Startup device check
 # ===========================================================================
 
 
-def gpu_offload_smoke_test() -> dict:
-    """Verify GPU availability by running a trivial round-trip kernel.
+def probe_gpu_device() -> dict:
+    """Check that a usable GPU is present, before the time loop starts.
+
+    This is a startup precondition of a --with-gpu run: it is called from
+    init_gpu() so that a missing device, a missing CUDA/ROCm runtime
+    or a GPU that cannot run a kernel fails immediately with a clear reason,
+    instead of somewhere inside the first timestep. The device name and memory it
+    returns are logged (for identifiable) run logs.
 
     Transfers a small array to the GPU, doubles each element, copies the result
-    back, and asserts correctness. Also queries device name and memory.
+    back and asserts correctness. Also queries device name and memory.
 
     Returns
     -------

--- a/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
+++ b/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
@@ -1,0 +1,894 @@
+# SPDX-FileCopyrightText: 2026 EBFM Authors
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+GPU kernels for the LOOP_SNOW module.
+
+Availability: numba.cuda kernels for compaction, heat conduction and
+percolation, offloaded to a GPU when the GPU backend is active (--with-gpu).
+
+The same kernels run on both vendors:
+- NVIDIA via stock numba.cuda,
+- AMD via numba.hip.pose_as_cuda() (see compute_backend.py).
+
+Each ``_*_kernel_gpu`` is the CUDA-thread equivalent of the corresponding
+``@njit`` kernel in LOOP_SNOW_kernels.py: the outer ``prange(gpsum)`` loop is
+replaced by a single CUDA thread index so one GPU thread handles one grid
+column. Per-column scratch arrays (suffix ``_ws``, shape ``(gpsum, nl)``) are
+pre-allocated on the device by ``SnowDeviceState`` to avoid dynamic allocation
+inside the kernels.
+
+``SnowDeviceState`` owns the device buffers for one LOOP_SNOW step: it uploads
+the subsurface state once, launches the compaction / heat-conduction /
+percolation kernels back-to-back while the shared arrays stay resident on the
+device, and copies every result back in one shot. The host-side physics glue
+lives in LOOP_SNOW.py (shared with the NumPy / Numba paths), so results match
+those paths exactly.
+
+When no GPU stack is importable, ``cuda`` is a no-op stub (from
+compute_backend), so the @cuda.jit-decorated functions remain importable but
+are never launched.
+"""
+
+import math
+
+import numpy as np
+
+from .compute_backend import cuda
+
+# Threads per block used for all 1-D column-parallel launches.
+_TPB = 128
+
+
+def _blocks(gpsum: int) -> int:
+    """Number of blocks needed to cover ``gpsum`` columns at ``_TPB`` threads each."""
+    return (gpsum + _TPB - 1) // _TPB
+
+
+# ---------------------------------------------------------------------------
+# Device helper functions
+#
+# Python's built-in max(), min(), abs() cannot be reliably used inside
+# @cuda.jit kernels across all numba/Python versions.  In Python 3.12+
+# (and especially 3.14) numba's CUDA type-inference maps them to a
+# single-argument overload, raising "2 argument types given, but function
+# takes 1 arguments" at JIT-compile time.  The CPU @njit path handles them
+# via a separate overload mechanism and is unaffected.
+#
+# @cuda.jit(device=True) functions are the canonical numba solution: they
+# are compiled once for the device, inlined at every call site, and work
+# on all supported numba versions and Python versions.
+#
+# When the GPU stack is absent (_CudaStub from compute_backend), the
+# decorator is a no-op, so the functions stay importable as plain Python.
+# ---------------------------------------------------------------------------
+
+
+@cuda.jit(device=True)
+def _fmax(a, b):
+    """max(a, b) for use inside GPU kernels (replaces Python built-in)."""
+    return a if a > b else b
+
+
+@cuda.jit(device=True)
+def _fmin(a, b):
+    """min(a, b) for use inside GPU kernels (replaces Python built-in)."""
+    return a if a < b else b
+
+
+@cuda.jit(device=True)
+def _fabs(x):
+    """abs(x) for use inside GPU kernels (replaces Python built-in)."""
+    return x if x >= 0.0 else -x
+
+
+# ===========================================================================
+# GPU kernels
+# ===========================================================================
+
+
+@cuda.jit
+def _gpu_probe_kernel(arr):
+    """Trivial kernel used only by gpu_offload_smoke_test().
+
+    Multiplies every element of ``arr`` by 2 to verify a GPU round-trip.
+    """
+    i = cuda.grid(1)
+    if i < arr.shape[0]:
+        arr[i] *= 2.0
+
+
+@cuda.jit
+def _compaction_kernel_gpu(
+    subD,
+    subZ,
+    subT,
+    subW,
+    subTmean,
+    subD_old,
+    logyearsnow,
+    yearsnow,
+    WS,
+    Dens_destr_metam,
+    Dens_overb_pres,
+    Dens_drift,
+    surfH,
+    sumWinit,
+    runoff_irr,
+    dt_yearfrac,
+    dt_seconds,
+    dt,
+    Dice,
+    Dfirn,
+    Dwater,
+    g,
+    T0,
+    rd,
+    Ec,
+    Eg,
+    dayseconds,
+    tau_drift,
+    compaction_mode,
+    was_snow_ws,  # (gpsum, nl) bool workspace
+    psload_ws,  # (gpsum, nl) float64 workspace
+):
+    """GPU equivalent of _compaction_kernel. One CUDA thread per grid column."""
+    i = cuda.grid(1)
+    if i >= subD.shape[0]:
+        return
+    nl = subD.shape[1]
+
+    # ------ 1. FIRN COMPACTION ------ #
+    for k in range(nl):
+        subTmean[i, k] = subTmean[i, k] * (1.0 - dt_yearfrac) + dt_yearfrac * subT[i, k]
+        cond_firn_k = (compaction_mode == 0) or (subD[i, k] >= Dfirn)
+        if cond_firn_k:
+            if subD[i, k] < 550.0:
+                grav_const = 0.07 * _fmax(1.435 - 0.151 * logyearsnow[i, k], 0.25)
+            else:
+                grav_const = 0.03 * _fmax(2.366 - 0.293 * logyearsnow[i, k], 0.25)
+            temp_factor = math.exp(-Ec / (rd * subT[i, k]) + Eg / (rd * subTmean[i, k]))
+            firn_inc = dt_yearfrac * grav_const * yearsnow[i, k] * g * (Dice - subD[i, k]) * temp_factor
+            subD[i, k] += firn_inc
+
+    # ------ 2. SEASONAL SNOW COMPACTION ------ #
+    if compaction_mode == 1:  # firn+snow
+        # Capture pre-DM snow mask
+        for k in range(nl):
+            was_snow_ws[i, k] = subD[i, k] < Dfirn
+
+        # ------ 2.1 DESTRUCTIVE METAMORPHISM ------ #
+        for k in range(nl):
+            if was_snow_ws[i, k]:
+                cc1 = math.exp(-0.046 * _fmax(subD[i, k] - 175.0, 0.0))
+                cc2 = 1.0 + (1.0 if subW[i, k] != 0.0 else 0.0)
+                temp_exp = math.exp(0.04 * (subT[i, k] - T0))
+                snow_inc = cc1 * cc2 * 2.777e-6 * temp_exp * dt_seconds * subD[i, k]
+                subD[i, k] = _fmin(subD[i, k] + snow_inc, Dice)
+                Dens_destr_metam[i, k] = snow_inc
+            else:
+                Dens_destr_metam[i, k] = 0.0
+
+        # ------ 2.2 OVERBURDEN PRESSURE ------ #
+        psload_ws[i, 0] = 0.5 * subD[i, 0] * subZ[i, 0] * g
+        for k in range(1, nl):
+            xm = subD[i, k - 1] * subZ[i, k - 1] * g
+            xk = subD[i, k] * subZ[i, k] * g
+            psload_ws[i, k] = psload_ws[i, k - 1] + 0.5 * (xm + xk)
+
+        for k in range(nl):
+            Dens_overb_pres[i, k] = 0.0
+            if was_snow_ws[i, k]:
+                cc7 = 4.0 * 7.62237e6 / 250.0 * subD[i, k] / (1.0 + 60.0 * subW[i, k] / (Dwater * subZ[i, k]))
+                visc = cc7 * math.exp(0.1 * (T0 - subT[i, k]) + 0.023 * subD[i, k])
+                overb_inc = dt * dayseconds * subD[i, k] * psload_ws[i, k] / visc
+                subD[i, k] = _fmin(subD[i, k] + overb_inc, Dice)
+                Dens_overb_pres[i, k] = dt * dayseconds * subD[i, k] * psload_ws[i, k] / visc
+
+        # ------ 2.3 DRIFTING SNOW ------ #
+        z_i_k = 0.0
+        for k in range(nl):
+            d_k = _fmax(subD[i, k], 50.0)
+            mo_k = -0.069 + 0.66 * (1.25 - 0.0042 * (d_k - 50.0))
+            si_k = -2.868 * math.exp(-0.085 * WS[i]) + 1.0 + mo_k
+            gamma_k = _fmax(0.0, si_k * math.exp(-z_i_k / 0.1))
+            Dens_drift[i, k] = 0.0
+            if si_k > 0.0 and subD[i, k] < Dfirn:
+                tau_i_k = tau_drift / gamma_k
+                drift_inc = dt_seconds * _fmax(350.0 - subD[i, k], 0.0) / tau_i_k
+                subD[i, k] = _fmin(subD[i, k] + drift_inc, Dice)
+                Dens_drift[i, k] = drift_inc
+            z_i_k += subZ[i, k] * (3.25 - si_k)
+
+    # ------ 3. UPDATE LAYER THICKNESS & SURFACE HEIGHT ------ #
+    z_sum = 0.0
+    z_sum_old = 0.0
+    subW_sum = 0.0
+    for k in range(nl):
+        # subZ is only read in sections 1-2, so subZ[i, k] still holds the
+        # pre-compaction thickness here. Take it before overwriting it below;
+        # no separate subZ_old array is needed.
+        z_old_k = subZ[i, k]
+        if subD[i, k] < Dice:
+            subZ[i, k] = z_old_k * subD_old[i, k] / subD[i, k]
+            exp_f = 0.0143 * math.exp(3.3 * (Dice - subD[i, k]) / Dice)
+            denom = 1.0 - exp_f
+            mliqmax_k = subD[i, k] * subZ[i, k] * exp_f / denom * 0.05 * _fmin(Dice - subD[i, k], 20.0)
+            if subW[i, k] > mliqmax_k:
+                subW[i, k] = mliqmax_k
+        else:
+            subW[i, k] = 0.0
+        z_sum += subZ[i, k]
+        z_sum_old += z_old_k
+        subW_sum += subW[i, k]
+
+    surfH[i] += z_sum - z_sum_old
+    runoff_irr[i] = sumWinit[i] - subW_sum
+
+
+@cuda.jit
+def _heat_conduction_kernel_gpu(
+    subT,
+    Tsurf,
+    kk_sz_top,
+    kk_sz_interior,
+    dz1,
+    dz2,
+    denom_layer1,
+    denom_interior,
+    denom_bottom,
+    dt_stab,
+    dt,
+    dayseconds,
+    geothermal_flux,
+    T_loc_ws,  # (gpsum, nl) float64 workspace — thread-local temperature copy
+    kdTdz_ws,  # (gpsum, nl) float64 workspace — heat flux scratch
+):
+    """GPU equivalent of _heat_conduction_kernel. One CUDA thread per grid column."""
+    i = cuda.grid(1)
+    if i >= subT.shape[0]:
+        return
+    nl = subT.shape[1]
+
+    for k in range(nl):
+        T_loc_ws[i, k] = subT[i, k]
+        kdTdz_ws[i, k] = 0.0
+
+    tt_i = 0.0
+    while tt_i < dt:
+        dt_temp_i = _fmin(dt_stab[i], dt - tt_i)
+        if dt_temp_i == 0.0:
+            break
+        tt_i += dt_temp_i
+        C_day_dt = dayseconds * dt_temp_i
+
+        # Freeze fluxes from current T_loc
+        kdTdz_ws[i, 1] = kk_sz_top[i] * (T_loc_ws[i, 1] - Tsurf[i]) / dz1[i]
+        for k in range(2, nl):
+            kdTdz_ws[i, k] = kk_sz_interior[i, k - 2] * (T_loc_ws[i, k] - T_loc_ws[i, k - 1]) / dz2[i, k - 2]
+
+        # Update T_loc in-place
+        T_loc_ws[i, 1] += C_day_dt * (kdTdz_ws[i, 2] - kdTdz_ws[i, 1]) / denom_layer1[i]
+        for k in range(2, nl - 1):
+            T_loc_ws[i, k] += C_day_dt * (kdTdz_ws[i, k + 1] - kdTdz_ws[i, k]) / denom_interior[i, k - 2]
+        T_loc_ws[i, nl - 1] += C_day_dt * (geothermal_flux - kdTdz_ws[i, nl - 1]) / denom_bottom[i]
+
+    for k in range(nl):
+        subT[i, k] = T_loc_ws[i, k]
+
+
+@cuda.jit
+def _percolation_kernel_gpu(
+    subT,
+    subD,
+    subW,
+    subS,
+    subZ,
+    avail_W,
+    RP,
+    runoff_surface,
+    runoff_slush,
+    refr_P,
+    refr_S,
+    refr_I,
+    slushw,
+    irrw,
+    T0,
+    Dice,
+    Dwater,
+    Lm,
+    Trunoff,
+    perc_depth,
+    percolation_mode,
+    dt,
+    wlim_ws,  # (gpsum, nl) float64 workspace
+    wirr_ws,  # (gpsum, nl) float64 workspace
+    carrot_ws,  # (gpsum, nl) float64 workspace
+    slushspace_ws,  # (gpsum, nl) float64 workspace
+):
+    """GPU equivalent of _percolation_kernel. One CUDA thread per grid column."""
+    i = cuda.grid(1)
+    if i >= subT.shape[0]:
+        return
+    nl = subT.shape[1]
+
+    sigma2_2 = 2.0 * (perc_depth / 3.0) ** 2
+    norm_coeff = 2.0 / (perc_depth / 3.0) / math.sqrt(2.0 * math.pi)
+    trunoff_factor = 1.0 / (1.0 + dt / Trunoff)
+
+    # ------ Refreezing and Irreducible Water Storage Limits ------ #
+    for k in range(nl):
+        cpi_k = 152.2 + 7.122 * subT[i, k]
+        c1_k = cpi_k * subD[i, k] * subZ[i, k] * (T0 - subT[i, k]) / Lm
+        c2_k = subZ[i, k] * (1.0 - subD[i, k] / Dice) * Dice
+        wlim_ws[i, k] = _fmax(_fmin(c1_k, c2_k), 0.0)
+        if subD[i, k] < Dice - 1.0:
+            factor_k = 3.3 * (Dice - subD[i, k]) / Dice
+            exp_f = math.exp(factor_k)
+            irr_f = 0.0143 * exp_f / (1.0 - 0.0143 * exp_f)
+            mliqmax_k = subD[i, k] * subZ[i, k] * irr_f * 0.05 * _fmin(Dice - subD[i, k], 20.0)
+        else:
+            mliqmax_k = 0.0
+        wirr_ws[i, k] = mliqmax_k - subW[i, k]
+
+    # ------ Carrot (water-distribution profile) ------ #
+    if percolation_mode == 0:
+        carrot_ws[i, 0] = 1.0
+        for k in range(1, nl):
+            carrot_ws[i, k] = 0.0
+    else:
+        depth = 0.0
+        for k in range(nl):
+            zz_k = depth + 0.5 * subZ[i, k]
+            if percolation_mode == 1:
+                carrot_ws[i, k] = norm_coeff * math.exp(-(zz_k * zz_k) / sigma2_2)
+            elif percolation_mode == 2:
+                v = 2.0 * (perc_depth - zz_k) / (perc_depth * perc_depth)
+                carrot_ws[i, k] = v if v > 0.0 else 0.0
+            else:
+                carrot_ws[i, k] = zz_k
+            depth += subZ[i, k]
+
+        if percolation_mode == 3:
+            min_dist = math.inf
+            ind = 0
+            for k in range(nl):
+                d = _fabs(carrot_ws[i, k] - perc_depth)
+                if d < min_dist:
+                    min_dist = d
+                    ind = k
+            for k in range(nl):
+                carrot_ws[i, k] = (1.0 / perc_depth) if k <= ind else 0.0
+
+    s = 0.0
+    for k in range(nl):
+        carrot_ws[i, k] *= subZ[i, k]
+        s += carrot_ws[i, k]
+    avail_W_i = avail_W[i]
+    for k in range(nl):
+        carrot_ws[i, k] = carrot_ws[i, k] / s * avail_W_i
+
+    # ------ Percolation: refreezing + irreducible storage ------ #
+    avail_W_loc = 0.0
+    rp_sum = 0.0
+    for n in range(nl):
+        avail_W_loc += carrot_ws[i, n]
+        rp_n = _fmin(avail_W_loc, wlim_ws[i, n])
+        RP[i, n] = rp_n
+        excess = avail_W_loc - wlim_ws[i, n]
+        if excess < 0.0:
+            excess = 0.0
+        # subW[i, n] still holds the pre-percolation value at this point; read
+        # it before overwriting, so no separate subW_old array is needed.
+        w_old_n = subW[i, n]
+        new_subW_n = w_old_n + _fmin(excess, wirr_ws[i, n])
+        subW[i, n] = new_subW_n
+        avail_W_loc -= rp_n + (new_subW_n - w_old_n)
+        cpi_n = 152.2 + 7.122 * subT[i, n]
+        subT[i, n] += Lm * rp_n / (subD[i, n] * cpi_n * subZ[i, n])
+        subD[i, n] += rp_n / subZ[i, n]
+        rp_sum += rp_n
+
+    avail_W[i] = avail_W_loc
+
+    # ------ Slush water storage ------ #
+    total_slushspace = 0.0
+    for k in range(nl):
+        ss_k = subZ[i, k] * (1.0 - subD[i, k] / Dice) * Dwater - subW[i, k]
+        if ss_k < 0.0:
+            ss_k = 0.0
+        slushspace_ws[i, k] = ss_k
+        total_slushspace += ss_k
+
+    old_slush_sum = 0.0
+    for k in range(nl):
+        old_slush_sum += subS[i, k]
+    avail_W_slush = avail_W_loc + old_slush_sum
+
+    surf_ro = avail_W_slush - total_slushspace
+    runoff_surface[i] = surf_ro if surf_ro > 0.0 else 0.0
+    avail_S = avail_W_slush if avail_W_slush < total_slushspace else total_slushspace
+    runoff_slush[i] = avail_S - trunoff_factor * avail_S
+    avail_S = trunoff_factor * avail_S
+    if avail_S < 1e-25:
+        avail_S = 0.0
+
+    for n in range(nl - 1, -1, -1):
+        fill = avail_S if avail_S < slushspace_ws[i, n] else slushspace_ws[i, n]
+        subS[i, n] = fill
+        avail_S -= fill
+
+    # ------ Slush refreezing ------ #
+    rs_sum = 0.0
+    for k in range(nl):
+        cpi_k = 152.2 + 7.122 * subT[i, k]
+        c1_k = cpi_k * subD[i, k] * subZ[i, k] * (T0 - subT[i, k]) / Lm
+        c2_k = subZ[i, k] * (1.0 - subD[i, k] / Dice) * Dice
+        wlim_k = _fmin(c1_k, c2_k)
+        rs_k = 0.0
+        if subS[i, k] > 0.0 and subT[i, k] < T0:
+            rs_k = subS[i, k] if subS[i, k] < wlim_k else wlim_k
+            if rs_k < 0.0:
+                rs_k = 0.0
+        subS[i, k] -= rs_k
+        subT[i, k] += (Lm * rs_k) / (subD[i, k] * cpi_k * subZ[i, k])
+        subD[i, k] += rs_k / subZ[i, k]
+        rs_sum += rs_k
+
+    # ------ Irreducible water refreezing ------ #
+    ri_sum = 0.0
+    for k in range(nl):
+        cpi_k = 152.2 + 7.122 * subT[i, k]
+        c1_k = cpi_k * subD[i, k] * subZ[i, k] * (T0 - subT[i, k]) / Lm
+        c2_k = subZ[i, k] * (1.0 - subD[i, k] / Dice) * Dice
+        wlim_k = _fmin(c1_k, c2_k)
+        ri_k = 0.0
+        if subW[i, k] > 0.0 and subT[i, k] < T0:
+            ri_k = subW[i, k] if subW[i, k] < wlim_k else wlim_k
+            if ri_k < 0.0:
+                ri_k = 0.0
+        subW[i, k] -= ri_k
+        subT[i, k] += (Lm * ri_k) / (subD[i, k] * cpi_k * subZ[i, k])
+        subD[i, k] += ri_k / subZ[i, k]
+        ri_sum += ri_k
+
+    slushw_i = 0.0
+    irrw_i = 0.0
+    for k in range(nl):
+        slushw_i += subS[i, k]
+        irrw_i += subW[i, k]
+    refr_P[i] = 1e-3 * rp_sum
+    refr_S[i] = 1e-3 * rs_sum
+    refr_I[i] = 1e-3 * ri_sum
+    slushw[i] = slushw_i
+    irrw[i] = irrw_i
+
+
+@cuda.jit
+def _heat_conduction_prep_kernel_gpu(
+    subD,  # (gpsum, nl)
+    subZ,  # (gpsum, nl)
+    subT,  # (gpsum, nl)
+    kk,  # (gpsum, nl)      out: effective conductivity (scratch)
+    c_eff,  # (gpsum, nl)      out: volumetric heat capacity (scratch)
+    kk_sz_top,  # (gpsum,)         out
+    kk_sz_interior,  # (gpsum, nl-2)    out
+    dz1,  # (gpsum,)         out
+    dz2,  # (gpsum, nl-2)    out
+    denom_layer1,  # (gpsum,)         out
+    denom_interior,  # (gpsum, nl-3)    out
+    denom_bottom,  # (gpsum,)         out
+    dt_stab,  # (gpsum,)         out
+    dayseconds,
+):
+    """On-device heat-conduction precompute. One CUDA thread per grid column.
+
+    Replaces the NumPy precompute block in heat_conduction() so that the
+    derived arrays are produced directly from the resident (post-compaction)
+    subD/subZ/subT without a host round-trip. Every formula is matched exactly
+    to the NumPy path in LOOP_SNOW.heat_conduction() for --dump-reference parity.
+    """
+    i = cuda.grid(1)
+    if i >= subD.shape[0]:
+        return
+    nl = subD.shape[1]
+
+    # Effective conductivity and volumetric heat capacity per layer.
+    for k in range(nl):
+        d = subD[i, k]
+        kk[i, k] = 0.138 - 1.01e-3 * d + 3.233e-6 * d * d
+        c_eff[i, k] = d * (152.2 + 7.122 * subT[i, k])
+
+    # dz1 = (subZ[0] + 0.5*subZ[1])**2
+    half1 = subZ[i, 0] + 0.5 * subZ[i, 1]
+    dz1[i] = half1 * half1
+
+    # dz2 = 0.5 * (subZ[k+2] + subZ[k+1])**2   (NumPy: 0.5*(a+b)**2, NOT (0.5*(a+b))**2)
+    for k in range(nl - 2):
+        s = subZ[i, k + 2] + subZ[i, k + 1]
+        dz2[i, k] = 0.5 * s * s
+
+    # kk_sz_top = kk[0]*subZ[0] + 0.5*kk[1]*subZ[1]
+    kk_sz_top[i] = kk[i, 0] * subZ[i, 0] + 0.5 * kk[i, 1] * subZ[i, 1]
+
+    # kk_sz_interior[j] = kk[j+1]*subZ[j+1] + kk[j+2]*subZ[j+2]
+    for k in range(nl - 2):
+        kk_sz_interior[i, k] = kk[i, k + 1] * subZ[i, k + 1] + kk[i, k + 2] * subZ[i, k + 2]
+
+    # denom_layer1 = c_eff[1] * (0.5*subZ[0] + 0.5*subZ[1] + 0.25*subZ[2])
+    denom_layer1[i] = c_eff[i, 1] * (0.5 * subZ[i, 0] + 0.5 * subZ[i, 1] + 0.25 * subZ[i, 2])
+
+    # denom_interior[k-2] = c_eff[k] * (0.25*subZ[k-1] + 0.5*subZ[k] + 0.25*subZ[k+1]) for k in 2..nl-2
+    for k in range(2, nl - 1):
+        denom_interior[i, k - 2] = c_eff[i, k] * (0.25 * subZ[i, k - 1] + 0.5 * subZ[i, k] + 0.25 * subZ[i, k + 1])
+
+    # denom_bottom = c_eff[-1] * (0.25*subZ[-2] + 0.75*subZ[-1])
+    denom_bottom[i] = c_eff[i, nl - 1] * (0.25 * subZ[i, nl - 2] + 0.75 * subZ[i, nl - 1])
+
+    # dt_stab = 0.5 * min(c_eff[1:]) * min(subZ[1:])**2 / max(kk[1:]) / dayseconds
+    min_ceff = math.inf
+    min_sz = math.inf
+    max_kk = 0.0
+    for k in range(1, nl):
+        if c_eff[i, k] < min_ceff:
+            min_ceff = c_eff[i, k]
+        if subZ[i, k] < min_sz:
+            min_sz = subZ[i, k]
+        if kk[i, k] > max_kk:
+            max_kk = kk[i, k]
+    dt_stab[i] = 0.5 * min_ceff * (min_sz * min_sz) / max_kk / dayseconds
+
+
+@cuda.jit
+def _heat_boundary_clip_kernel_gpu(subT, Tsurf, subZ, T0):
+    """Surface ghost-layer update + melting-point clip. One thread per column.
+
+    Matches the NumPy post-processing at the end of heat_conduction():
+        subT[:,0] = Tsurf + (subT[:,1]-Tsurf)/(subZ[:,0]+0.5*subZ[:,1]) * 0.5*subZ[:,0]
+        np.clip(subT, None, T0, out=subT)
+    """
+    i = cuda.grid(1)
+    if i >= subT.shape[0]:
+        return
+    nl = subT.shape[1]
+
+    subT[i, 0] = Tsurf[i] + (subT[i, 1] - Tsurf[i]) / (subZ[i, 0] + 0.5 * subZ[i, 1]) * 0.5 * subZ[i, 0]
+    for k in range(nl):
+        if subT[i, k] > T0:
+            subT[i, k] = T0
+
+
+# ===========================================================================
+# Device-resident state for one LOOP_SNOW step.
+#
+# SnowDeviceState keeps the subsurface arrays (subT/subD/subZ/subW/subS/
+# subTmean/surfH) on the GPU across the three snow sub-steps -- compaction,
+# heat conduction, percolation -- so they are uploaded once and downloaded
+# once per timestep instead of round-tripping per sub-step.
+#
+# The host-side physics glue (mode selection, water-input formula, unit
+# conventions, output bookkeeping) stays in LOOP_SNOW.py, which is the single
+# source of truth shared with the NumPy and Numba paths. This class only owns
+# the device buffers and launches the five compute kernels above against them,
+# so --dump-reference parity with the NumPy/Numba paths is preserved.
+#
+# NOTE (lifetime): one instance currently lives for a single LOOP_SNOW step
+# (created after melt_sublimation, discarded after percolation), so the
+# transfer profile matches the previous fused core -- upload once, download
+# once per step. Hoisting the instance out of the time loop so the state
+# persists across timesteps -- syncing only subZ/subD/Tsurf at the LOOP_EBM /
+# LOOP_mass_balance boundary -- is the follow-up that turns the once-per-step
+# transfers into once-per-run.
+# ===========================================================================
+
+
+class SnowDeviceState:
+    """GPU-resident subsurface state for one LOOP_SNOW step.
+
+    Uploads the resident arrays and this step's inputs on construction, exposes
+    compaction() / heat_conduction() / percolation() that launch their kernels
+    against the resident device arrays, and download() to copy every result
+    back into the OUT dict in one shot.
+    """
+
+    def __init__(
+        self,
+        subT,
+        subD,
+        subZ,
+        subW,
+        subS,
+        subTmean,
+        surfH,
+        logyearsnow,
+        yearsnow,
+        WS,
+        Tsurf,
+        sumWinit,
+    ):
+        gpsum, nl = subD.shape
+        self.blocks = _blocks(gpsum)
+
+        # Resident state (read/write; copied back in download()).
+        self.subT = cuda.to_device(subT)
+        self.subD = cuda.to_device(subD)
+        self.subZ = cuda.to_device(subZ)
+        self.subW = cuda.to_device(subW)
+        self.subS = cuda.to_device(subS)
+        self.subTmean = cuda.to_device(subTmean)
+        self.surfH = cuda.to_device(surfH)
+
+        # Per-step inputs (read-only on the device).
+        self.logyearsnow = cuda.to_device(logyearsnow)
+        self.yearsnow = cuda.to_device(yearsnow)
+        self.WS = cuda.to_device(WS)
+        self.Tsurf = cuda.to_device(Tsurf)
+        self.sumWinit = cuda.to_device(sumWinit)
+
+        # Conductivity / heat capacity filled by the heat-conduction prep kernel
+        # and kept resident so download() returns subK/subCeff matching NumPy.
+        self.kk = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self.c_eff = cuda.device_array((gpsum, nl), dtype=np.float64)
+
+        # Write-only column outputs (allocated, never uploaded).
+        self.runoff_irr = cuda.device_array((gpsum,), dtype=np.float64)
+        self.runoff_surface = cuda.device_array((gpsum,), dtype=np.float64)
+        self.runoff_slush = cuda.device_array((gpsum,), dtype=np.float64)
+        self.refr_P = cuda.device_array((gpsum,), dtype=np.float64)
+        self.refr_S = cuda.device_array((gpsum,), dtype=np.float64)
+        self.refr_I = cuda.device_array((gpsum,), dtype=np.float64)
+        self.slushw = cuda.device_array((gpsum,), dtype=np.float64)
+        self.irrw = cuda.device_array((gpsum,), dtype=np.float64)
+
+        # Dens_* diagnostics: uploaded in compaction() as host zeros so that
+        # firn_only mode (where the kernel does not touch them) stays zero.
+        self.Dens_destr_metam = None
+        self.Dens_overb_pres = None
+        self.Dens_drift = None
+
+        # Device-only scratch (never touches the host).
+        self._subD_old = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self._was_snow_ws = cuda.device_array((gpsum, nl), dtype=np.bool_)
+        self._psload_ws = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self._kk_sz_top = cuda.device_array((gpsum,), dtype=np.float64)
+        self._kk_sz_interior = cuda.device_array((gpsum, nl - 2), dtype=np.float64)
+        self._dz1 = cuda.device_array((gpsum,), dtype=np.float64)
+        self._dz2 = cuda.device_array((gpsum, nl - 2), dtype=np.float64)
+        self._denom_layer1 = cuda.device_array((gpsum,), dtype=np.float64)
+        self._denom_interior = cuda.device_array((gpsum, nl - 3), dtype=np.float64)
+        self._denom_bottom = cuda.device_array((gpsum,), dtype=np.float64)
+        self._dt_stab = cuda.device_array((gpsum,), dtype=np.float64)
+        self._T_loc_ws = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self._kdTdz_ws = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self._RP = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self._wlim_ws = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self._wirr_ws = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self._carrot_ws = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self._slushspace_ws = cuda.device_array((gpsum, nl), dtype=np.float64)
+
+    def compaction(
+        self,
+        Dens_destr_metam,
+        Dens_overb_pres,
+        Dens_drift,
+        dt_yearfrac,
+        dt_seconds,
+        dt,
+        C,
+        tau_drift,
+        mode,
+    ):
+        """Launch the compaction kernel on the resident arrays."""
+        # Upload host-zeroed diagnostics; firn_only leaves them untouched.
+        self.Dens_destr_metam = cuda.to_device(Dens_destr_metam)
+        self.Dens_overb_pres = cuda.to_device(Dens_overb_pres)
+        self.Dens_drift = cuda.to_device(Dens_drift)
+
+        # Snapshot pre-compaction subD/subZ on-device (host path does .copy()).
+        self._subD_old.copy_to_device(self.subD)
+
+        _compaction_kernel_gpu[self.blocks, _TPB](
+            self.subD,
+            self.subZ,
+            self.subT,
+            self.subW,
+            self.subTmean,
+            self._subD_old,
+            self.logyearsnow,
+            self.yearsnow,
+            self.WS,
+            self.Dens_destr_metam,
+            self.Dens_overb_pres,
+            self.Dens_drift,
+            self.surfH,
+            self.sumWinit,
+            self.runoff_irr,
+            dt_yearfrac,
+            dt_seconds,
+            dt,
+            C["Dice"],
+            C["Dfirn"],
+            C["Dwater"],
+            C["g"],
+            C["T0"],
+            C["rd"],
+            C["Ec"],
+            C["Eg"],
+            C["dayseconds"],
+            tau_drift,
+            mode,
+            self._was_snow_ws,
+            self._psload_ws,
+        )
+
+    def heat_conduction(self, dt, C):
+        """Launch heat-conduction prep, solve and boundary/clip, all on-device."""
+        _heat_conduction_prep_kernel_gpu[self.blocks, _TPB](
+            self.subD,
+            self.subZ,
+            self.subT,
+            self.kk,
+            self.c_eff,
+            self._kk_sz_top,
+            self._kk_sz_interior,
+            self._dz1,
+            self._dz2,
+            self._denom_layer1,
+            self._denom_interior,
+            self._denom_bottom,
+            self._dt_stab,
+            C["dayseconds"],
+        )
+        _heat_conduction_kernel_gpu[self.blocks, _TPB](
+            self.subT,
+            self.Tsurf,
+            self._kk_sz_top,
+            self._kk_sz_interior,
+            self._dz1,
+            self._dz2,
+            self._denom_layer1,
+            self._denom_interior,
+            self._denom_bottom,
+            self._dt_stab,
+            dt,
+            C["dayseconds"],
+            C["geothermal_flux"],
+            self._T_loc_ws,
+            self._kdTdz_ws,
+        )
+        _heat_boundary_clip_kernel_gpu[self.blocks, _TPB](
+            self.subT,
+            self.Tsurf,
+            self.subZ,
+            C["T0"],
+        )
+
+    def percolation(self, avail_W, C, perc_mode, dt):
+        """Launch the percolation kernel on the resident arrays."""
+        d_avail_W = cuda.to_device(avail_W)
+        # Snapshot post-heat subW on-device (host path does subW.copy()).
+        _percolation_kernel_gpu[self.blocks, _TPB](
+            self.subT,
+            self.subD,
+            self.subW,
+            self.subS,
+            self.subZ,
+            d_avail_W,
+            self._RP,
+            self.runoff_surface,
+            self.runoff_slush,
+            self.refr_P,
+            self.refr_S,
+            self.refr_I,
+            self.slushw,
+            self.irrw,
+            C["T0"],
+            C["Dice"],
+            C["Dwater"],
+            C["Lm"],
+            C["Trunoff"],
+            C["perc_depth"],
+            perc_mode,
+            dt,
+            self._wlim_ws,
+            self._wirr_ws,
+            self._carrot_ws,
+            self._slushspace_ws,
+        )
+
+    def download(self, OUT):
+        """Copy the resident state and every output back into OUT (once)."""
+        # Resident state: written back in place, preserving array identity.
+        self.subT.copy_to_host(OUT["subT"])
+        self.subD.copy_to_host(OUT["subD"])
+        self.subZ.copy_to_host(OUT["subZ"])
+        self.subW.copy_to_host(OUT["subW"])
+        self.subS.copy_to_host(OUT["subS"])
+        self.subTmean.copy_to_host(OUT["subTmean"])
+        self.surfH.copy_to_host(OUT["surfH"])
+        self.Dens_destr_metam.copy_to_host(OUT["Dens_destr_metam"])
+        self.Dens_overb_pres.copy_to_host(OUT["Dens_overb_pres"])
+        self.Dens_drift.copy_to_host(OUT["Dens_drift"])
+        self.runoff_irr.copy_to_host(OUT["runoff_irr"])
+
+        # Percolation outputs. refr_* already carry the 1e-3 factor from the
+        # kernel; runoff_* stay in mm and are scaled later in runoff().
+        OUT["runoff_surface"] = self.runoff_surface.copy_to_host()
+        OUT["runoff_slush"] = self.runoff_slush.copy_to_host()
+        OUT["refr_P"] = self.refr_P.copy_to_host()
+        OUT["refr_S"] = self.refr_S.copy_to_host()
+        OUT["refr_I"] = self.refr_I.copy_to_host()
+        OUT["slushw"] = self.slushw.copy_to_host()
+        OUT["irrw"] = self.irrw.copy_to_host()
+        OUT["refr"] = OUT["refr_P"] + OUT["refr_S"] + OUT["refr_I"]
+
+        # subK / subCeff are the post-compaction conductivity and heat capacity
+        # (from the prep kernel), matching the NumPy path's pre-heat-solve
+        # values. cpi is a diagnostic recomputed from the final subT; as in the
+        # per-call GPU path this differs from NumPy only at the last refreezing
+        # sub-step and is not consumed downstream.
+        self.kk.copy_to_host(OUT["subK"])
+        self.c_eff.copy_to_host(OUT["subCeff"])
+        OUT["cpi"] = 152.2 + 7.122 * OUT["subT"]
+
+
+# ===========================================================================
+# Smoke test
+# ===========================================================================
+
+
+def gpu_offload_smoke_test() -> dict:
+    """Verify GPU availability by running a trivial round-trip kernel.
+
+    Transfers a small array to the GPU, doubles each element, copies the result
+    back, and asserts correctness. Also queries device name and memory.
+
+    Returns
+    -------
+    dict
+        ``{"available": True, "device_name": ..., "free_mem_gb": ...,
+           "total_mem_gb": ...}`` on success, or
+        ``{"available": False, "reason": ...}`` on failure.
+    """
+    try:
+        devices = list(cuda.list_devices())
+    except Exception as exc:
+        return {"available": False, "reason": f"cuda.list_devices() failed: {exc}"}
+
+    if not devices:
+        return {"available": False, "reason": "no CUDA/ROCm devices detected"}
+
+    device = devices[0]
+    try:
+        device_name = device.name.decode() if isinstance(device.name, bytes) else str(device.name)
+    except Exception:
+        device_name = repr(device)
+
+    try:
+        with cuda.gpus[0]:
+            free_bytes, total_bytes = cuda.current_context().get_memory_info()
+    except Exception as exc:
+        return {"available": False, "reason": f"failed to query device memory: {exc}"}
+
+    # Round-trip test: allocate 32 ones, double on GPU, assert result == 2.
+    host_arr = np.ones(32, dtype=np.float64)
+    try:
+        d_arr = cuda.to_device(host_arr)
+        _gpu_probe_kernel[4, 8](d_arr)  # 4 blocks x 8 threads = 32 threads
+        result = d_arr.copy_to_host()
+    except Exception as exc:
+        return {"available": False, "reason": f"GPU kernel launch failed: {exc}"}
+
+    if not np.allclose(result, 2.0):
+        return {
+            "available": False,
+            "reason": f"GPU result mismatch: expected 2.0, got max={result.max():.6g}",
+        }
+
+    return {
+        "available": True,
+        "device_name": device_name,
+        "free_mem_gb": free_bytes / 2**30,
+        "total_mem_gb": total_bytes / 2**30,
+    }

--- a/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
+++ b/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: 2026 EBFM Authors
 #
 # SPDX-License-Identifier: BSD-3-Clause
+#
+# Content partially generated with the assistance of AI tools.
+# Claude Code: Opus 5
 
 """
 GPU kernels for the LOOP_SNOW module.

--- a/src/ebfm/core/cli.py
+++ b/src/ebfm/core/cli.py
@@ -381,9 +381,9 @@ def parse_cli_args(args: list[str] | None = None) -> Namespace:
         action="store_true",
         default=False,
         help=(
-            "Offload the kernels (compaction, heat conduction, percolation) to a GPU "
+            "Offload kernels (compaction, heat conduction, percolation) to a GPU "
             "via numba.cuda (NVIDIA) or numba.hip (AMD). Mutually exclusive with --with-numba. "
-            "Requires numba with GPU support; install via: pip install 'ebfm[gpu]' and load the "
+            "Requires numba with GPU support. Install via: pip install 'ebfm[gpu]' and load the "
             "CUDA/ROCm toolkit on the compute node."
         ),
     )
@@ -395,8 +395,7 @@ def parse_cli_args(args: list[str] | None = None) -> Namespace:
         default="auto",
         help=(
             "GPU vendor to target when using --with-gpu. 'auto' detects the installed numba GPU "
-            "stack (numba.cuda for NVIDIA, numba.hip for AMD); 'nvidia'/'amd' additionally guard "
-            "against a mismatch with the detected stack."
+            "stack (numba.cuda for NVIDIA, numba.hip for AMD)."
         ),
     )
 

--- a/src/ebfm/core/cli.py
+++ b/src/ebfm/core/cli.py
@@ -376,6 +376,30 @@ def parse_cli_args(args: list[str] | None = None) -> Namespace:
         help=("Enable the parallel Numba kernel. " "Requires numba; install via: pip install 'ebfm[performance]'. "),
     )
 
+    performance_group.add_argument(
+        "--with-gpu",
+        action="store_true",
+        default=False,
+        help=(
+            "Offload the kernels (compaction, heat conduction, percolation) to a GPU "
+            "via numba.cuda (NVIDIA) or numba.hip (AMD). Mutually exclusive with --with-numba. "
+            "Requires numba with GPU support; install via: pip install 'ebfm[gpu]' and load the "
+            "CUDA/ROCm toolkit on the compute node."
+        ),
+    )
+
+    performance_group.add_argument(
+        "--gpu-vendor",
+        type=str,
+        choices=("auto", "nvidia", "amd"),
+        default="auto",
+        help=(
+            "GPU vendor to target when using --with-gpu. 'auto' detects the installed numba GPU "
+            "stack (numba.cuda for NVIDIA, numba.hip for AMD); 'nvidia'/'amd' additionally guard "
+            "against a mismatch with the detected stack."
+        ),
+    )
+
     # Add args for features requiring 'import coupling'
     add_coupling_arguments(parser)
 
@@ -390,6 +414,12 @@ def parse_cli_args(args: list[str] | None = None) -> Namespace:
 
     if args.elmer_mesh and args.elmer_mesh_crs_epsg is None:
         parser.error("--elmer-mesh-crs-epsg is required when using --elmer-mesh")
+
+    if args.with_numba and args.with_gpu:
+        parser.error("--with-numba and --with-gpu are mutually exclusive.")
+
+    if args.gpu_vendor != "auto" and not args.with_gpu:
+        parser.error("--gpu-vendor requires --with-gpu.")
 
     if not hasattr(args, "local_group_label"):
         args.local_group_label = args.component_name

--- a/src/ebfm/core/compute_backend.py
+++ b/src/ebfm/core/compute_backend.py
@@ -66,7 +66,7 @@ except ImportError:
 # happens at IMPORT time, because kernel decoration is import-time.
 #
 # _GPU_AVAILABLE only means the GPU stack is importable. Presence of a usable
-# device is confirmed separately by the smoke test in init_gpu().
+# device is confirmed separately by probe_gpu_device() in init_gpu().
 # ---------------------------------------------------------------------------
 _GPU_AVAILABLE = False
 _GPU_VENDOR: str | None = None  # "nvidia" | "amd" | None
@@ -131,7 +131,7 @@ def is_gpu_available() -> bool:
     """Return True if a GPU stack (numba.cuda or numba.hip) is importable.
 
     Note: this does not guarantee a usable device is present. That is verified
-    by the smoke test run inside init_gpu().
+    by probe_gpu_device(), run inside init_gpu().
     """
     return _GPU_AVAILABLE
 
@@ -161,7 +161,7 @@ def init_numba(n_threads: int = 1):
 def init_gpu(vendor: str = "auto", logger=None):
     """Activate the GPU backend after confirming a usable device.
 
-    Runs a small round-trip smoke test to verify the device works before
+    Runs probe_gpu_device() to verify a usable device is present before
     switching the backend. Must be called before any kernel runs (i.e. before
     the time loop).
 
@@ -183,11 +183,11 @@ def init_gpu(vendor: str = "auto", logger=None):
         )
 
     # Imported lazily to avoid a circular import at module load time.
-    from ebfm.core.LOOP_SNOW_gpu_kernels import gpu_offload_smoke_test
+    from ebfm.core.LOOP_SNOW_gpu_kernels import probe_gpu_device
 
-    smoke = gpu_offload_smoke_test()
-    if not smoke.get("available", False):
-        raise RuntimeError(f"GPU smoke test failed: {smoke.get('reason', 'unknown error')}")
+    device = probe_gpu_device()
+    if not device.get("available", False):
+        raise RuntimeError(f"GPU device check failed: {device.get('reason', 'unknown error')}")
 
     global _backend
     _backend = ComputeBackend.GPU
@@ -196,7 +196,7 @@ def init_gpu(vendor: str = "auto", logger=None):
         logger.info(
             "[GPU] backend enabled (%s). Device: %s  free=%.2f GiB  total=%.2f GiB",
             _GPU_VENDOR,
-            smoke["device_name"],
-            smoke["free_mem_gb"],
-            smoke["total_mem_gb"],
+            device["device_name"],
+            device["free_mem_gb"],
+            device["total_mem_gb"],
         )

--- a/src/ebfm/core/compute_backend.py
+++ b/src/ebfm/core/compute_backend.py
@@ -65,14 +65,14 @@ except ImportError:
 # makes `from numba import cuda` delegate to HIP.  Vendor detection therefore
 # happens at IMPORT time, because kernel decoration is import-time.
 #
-# _GPU_AVAILABLE only means the GPU stack is importable; presence of a usable
+# _GPU_AVAILABLE only means the GPU stack is importable. Presence of a usable
 # device is confirmed separately by the smoke test in init_gpu().
 # ---------------------------------------------------------------------------
 _GPU_AVAILABLE = False
 _GPU_VENDOR: str | None = None  # "nvidia" | "amd" | None
 
 try:
-    # AMD path: numba-hip provides `numba.hip`; pose_as_cuda() makes the stock
+    # AMD path: numba-hip provides `numba.hip`; pose_as_cuda() makes
     # `from numba import cuda` kernels run on gfx GPUs unchanged.
     from numba import hip as _hip
 
@@ -83,7 +83,7 @@ try:
     _GPU_VENDOR = "amd"
 except ImportError:
     try:
-        # NVIDIA path: stock numba.cuda (bundled numba-cuda for numba >= 0.62).
+        # NVIDIA path: numba.cuda (bundled numba-cuda for numba >= 0.62).
         from numba import cuda  # noqa: F401
 
         _GPU_AVAILABLE = True
@@ -130,7 +130,7 @@ def is_numba_available() -> bool:
 def is_gpu_available() -> bool:
     """Return True if a GPU stack (numba.cuda or numba.hip) is importable.
 
-    Note: this does not guarantee a usable device is present; that is verified
+    Note: this does not guarantee a usable device is present. That is verified
     by the smoke test run inside init_gpu().
     """
     return _GPU_AVAILABLE

--- a/src/ebfm/core/compute_backend.py
+++ b/src/ebfm/core/compute_backend.py
@@ -31,7 +31,7 @@ from enum import Enum
 class ComputeBackend(Enum):
     NUMPY = "numpy"
     NUMBA = "numba"
-    # CUDA = "cuda"  # future
+    GPU = "gpu"  # numba.cuda (NVIDIA) or numba.hip (AMD)
 
 
 _backend = ComputeBackend.NUMPY
@@ -58,6 +58,61 @@ except ImportError:
 
 
 # ---------------------------------------------------------------------------
+# GPU (CUDA / ROCm-HIP) availability and the `cuda` handle used to decorate
+# GPU kernels (@cuda.jit) in LOOP_SNOW_gpu_kernels.py.
+#
+# The same numba.cuda kernels also run on AMD GPUs: numba.hip.pose_as_cuda()
+# makes `from numba import cuda` delegate to HIP.  Vendor detection therefore
+# happens at IMPORT time, because kernel decoration is import-time.
+#
+# _GPU_AVAILABLE only means the GPU stack is importable; presence of a usable
+# device is confirmed separately by the smoke test in init_gpu().
+# ---------------------------------------------------------------------------
+_GPU_AVAILABLE = False
+_GPU_VENDOR: str | None = None  # "nvidia" | "amd" | None
+
+try:
+    # AMD path: numba-hip provides `numba.hip`; pose_as_cuda() makes the stock
+    # `from numba import cuda` kernels run on gfx GPUs unchanged.
+    from numba import hip as _hip
+
+    _hip.pose_as_cuda()
+    from numba import cuda  # noqa: F401  (now backed by HIP)
+
+    _GPU_AVAILABLE = True
+    _GPU_VENDOR = "amd"
+except ImportError:
+    try:
+        # NVIDIA path: stock numba.cuda (bundled numba-cuda for numba >= 0.62).
+        from numba import cuda  # noqa: F401
+
+        _GPU_AVAILABLE = True
+        _GPU_VENDOR = "nvidia"
+    except ImportError:
+        _GPU_AVAILABLE = False
+        _GPU_VENDOR = None
+
+        class _CudaStub:
+            """No-op stand-in so @cuda.jit stays importable without a GPU stack."""
+
+            @staticmethod
+            def jit(fn=None, **kwargs):
+                if fn is not None:
+                    return fn
+
+                def _wrap(f):
+                    return f
+
+                return _wrap
+
+            @staticmethod
+            def grid(*args):
+                return 0
+
+        cuda = _CudaStub()  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -70,6 +125,20 @@ def get_backend() -> ComputeBackend:
 def is_numba_available() -> bool:
     """Return True if numba is installed and importable."""
     return _NUMBA_AVAILABLE
+
+
+def is_gpu_available() -> bool:
+    """Return True if a GPU stack (numba.cuda or numba.hip) is importable.
+
+    Note: this does not guarantee a usable device is present; that is verified
+    by the smoke test run inside init_gpu().
+    """
+    return _GPU_AVAILABLE
+
+
+def get_gpu_vendor() -> str | None:
+    """Return the detected GPU vendor ("nvidia", "amd") or None if unavailable."""
+    return _GPU_VENDOR
 
 
 def init_numba(n_threads: int = 1):
@@ -87,3 +156,47 @@ def init_numba(n_threads: int = 1):
 
     global _backend
     _backend = ComputeBackend.NUMBA
+
+
+def init_gpu(vendor: str = "auto", logger=None):
+    """Activate the GPU backend after confirming a usable device.
+
+    Runs a small round-trip smoke test to verify the device works before
+    switching the backend. Must be called before any kernel runs (i.e. before
+    the time loop).
+
+    @param vendor "auto" | "nvidia" | "amd"; when not "auto", guards against a
+                  mismatch with the import-time detected GPU stack.
+    @param logger optional logger for the device info message.
+    """
+    if not _GPU_AVAILABLE:
+        raise RuntimeError(
+            "GPU backend unavailable: could not import numba.cuda (NVIDIA) or "
+            "numba.hip (AMD). Install via: pip install 'ebfm[gpu]' and load the "
+            "CUDA/ROCm toolkit on the compute node."
+        )
+
+    if vendor != "auto" and vendor != _GPU_VENDOR:
+        raise RuntimeError(
+            f"--gpu-vendor={vendor} requested but the detected GPU stack is "
+            f"'{_GPU_VENDOR}'. Load the matching toolkit or use --gpu-vendor auto."
+        )
+
+    # Imported lazily to avoid a circular import at module load time.
+    from ebfm.core.LOOP_SNOW_gpu_kernels import gpu_offload_smoke_test
+
+    smoke = gpu_offload_smoke_test()
+    if not smoke.get("available", False):
+        raise RuntimeError(f"GPU smoke test failed: {smoke.get('reason', 'unknown error')}")
+
+    global _backend
+    _backend = ComputeBackend.GPU
+
+    if logger is not None:
+        logger.info(
+            "[GPU] backend enabled (%s). Device: %s  free=%.2f GiB  total=%.2f GiB",
+            _GPU_VENDOR,
+            smoke["device_name"],
+            smoke["free_mem_gb"],
+            smoke["total_mem_gb"],
+        )

--- a/src/ebfm/core/config/time.py
+++ b/src/ebfm/core/config/time.py
@@ -76,6 +76,7 @@ def _parse_time(time_str: str) -> datetime:
     dt: datetime
     try:
         import sys
+
         if sys.version_info < (3, 11) and time_str.endswith("Z"):
             # Python < 3.11 does not support parsing ISO 8601 timestamps
             # with a trailing 'Z' UTC designator.

--- a/src/ebfm/core/logger.py
+++ b/src/ebfm/core/logger.py
@@ -99,6 +99,15 @@ def setup_logging(
     stderr_handler.setLevel(logging.ERROR)
     root_logger.addHandler(stderr_handler)
 
+    # numba.cuda / numba-hip log every GPU malloc/free at INFO level via
+    # internal driver loggers, which is noisy. Raise them to WARNING.
+    for noisy_logger in (
+        "numba.cuda.cudadrv.driver",
+        "numba.hip.hipdrv.driver",
+        "numba.hip.hipdrv.devicearray",
+    ):
+        logging.getLogger(noisy_logger).setLevel(logging.WARNING)
+
     root_logger.debug("Logging setup complete.")
 
 

--- a/src/ebfm/main.py
+++ b/src/ebfm/main.py
@@ -139,9 +139,14 @@ def _main_impl():
 
         n_threads = resolve_numba_threads(args, ebfm_comm, logger)
         init_numba(n_threads)
+    elif args.with_gpu:
+        from ebfm.core.compute_backend import init_gpu
+
+        init_gpu(args.gpu_vendor, logger)
     else:
         logger.info(
-            "Pass --with-numba to enable the parallel Numba kernels " "(requires: pip install 'ebfm[performance]')."
+            "Pass --with-numba to enable the parallel Numba kernels, or --with-gpu to offload them "
+            "to a GPU (requires: pip install 'ebfm[performance]' / 'ebfm[gpu]')."
         )
 
     logger.info("Done parsing command line arguments.")

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -139,6 +139,12 @@ class TestDefaults(unittest.TestCase):
     def test_numba_threads_default_none(self):
         self.assertIsNone(self.args.numba_threads)
 
+    def test_with_gpu_default_false(self):
+        self.assertFalse(self.args.with_gpu)
+
+    def test_gpu_vendor_default_auto(self):
+        self.assertEqual(self.args.gpu_vendor, "auto")
+
     def test_no_coupling_by_default(self):
         self.assertFalse(self.args.couple_to_elmer_ice)
         self.assertFalse(self.args.couple_to_icon_atmo)
@@ -148,6 +154,33 @@ class TestDefaults(unittest.TestCase):
 
     def test_random_seed_default_none(self):
         self.assertIsNone(self.args.random_seed)
+
+
+class TestGpuOptions(unittest.TestCase):
+    """--with-gpu / --gpu-vendor parsing and compatibility checks."""
+
+    def test_with_gpu_accepted(self):
+        args = _parse("--with-gpu")
+        self.assertTrue(args.with_gpu)
+
+    def test_gpu_vendor_accepted(self):
+        args = _parse("--with-gpu", "--gpu-vendor", "nvidia")
+        self.assertEqual(args.gpu_vendor, "nvidia")
+
+    def test_gpu_vendor_invalid_rejected(self):
+        with self.assertRaises(SystemExit) as ctx:
+            _parse("--with-gpu", "--gpu-vendor", "intel")
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_with_gpu_and_with_numba_rejected(self):
+        with self.assertRaises(SystemExit) as ctx:
+            _parse("--with-gpu", "--with-numba")
+        self.assertEqual(ctx.exception.code, 2)
+
+    def test_gpu_vendor_without_with_gpu_rejected(self):
+        with self.assertRaises(SystemExit) as ctx:
+            _parse("--gpu-vendor", "nvidia")
+        self.assertEqual(ctx.exception.code, 2)
 
 
 class TestLocalGroupLabel(unittest.TestCase):

--- a/tests/core/test_loop_snow_gpu.py
+++ b/tests/core/test_loop_snow_gpu.py
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: 2026 EBFM Authors
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""
+Correctness gate for the GPU backend of LOOP_SNOW.
+
+Runs the whole snow model on both the NumPy and the GPU backend from an
+identical state and requires the results to agree to the same tolerance the
+--dump-reference gate uses (atol=1e-12, rtol=1e-9).
+
+No GPU is needed: numba's CUDA simulator (NUMBA_ENABLE_CUDASIM=1) executes the
+@cuda.jit kernels on the CPU, one Python thread per grid column. This is slow,
+so the grid here is deliberately tiny. It is a logic check, not a benchmark.
+The simulator has to be enabled before numba is first imported, which is why
+this module sets the environment variable at import time and is skipped when
+numba was already imported without it.
+
+Note that the simulator only checks kernel logic. Device-specific behaviour
+(occupancy, races between blocks, driver/toolkit issues) is not covered here
+and is verified with --dump-reference on real hardware.
+"""
+
+import os
+import unittest
+import warnings
+
+import numpy as np
+
+# Must happen before `from numba import cuda` anywhere in the process.
+os.environ.setdefault("NUMBA_ENABLE_CUDASIM", "1")
+
+_CUDASIM = os.environ.get("NUMBA_ENABLE_CUDASIM") == "1"
+
+try:
+    import numba  # noqa: F401
+
+    _NUMBA = True
+except ImportError:  # pragma: no cover, numba is an optional dependency
+    _NUMBA = False
+
+
+def _make_case(gpsum=48, nl=50, seed=7):
+    """Build a small but non-degenerate LOOP_SNOW state.
+
+    The columns are randomised across the regimes the kernels branch on: snow
+    and firn and solid ice densities, wet and dry layers, columns that gain
+    enough snow to shift the grid down and columns that melt enough to shift it
+    up, and layer thicknesses on both sides of the merge/split thresholds.
+    """
+    from ebfm.core import INIT
+
+    rng = np.random.default_rng(seed)
+    C = INIT.init_constants()
+
+    grid = {
+        "gpsum": gpsum,
+        "nl": nl,
+        "max_subZ": 0.1,
+        "doubledepth": True,
+        "split": np.array([15, 25, 35]),
+        "mask": np.ones(gpsum, dtype=int),
+    }
+    # A few inactive columns, so the kernel's mask early-out is exercised.
+    grid["mask"][:3] = 0
+
+    phys = {"snow_compaction": "firn+snow", "percolation": "normal"}
+    dt = 1.0 / 24.0
+
+    OUT = {}
+    OUT["subT"] = C["T0"] - rng.uniform(0.0, 25.0, (gpsum, nl))
+    OUT["subTmean"] = OUT["subT"] - rng.uniform(0.0, 5.0, (gpsum, nl))
+    OUT["subD"] = rng.uniform(250.0, 900.0, (gpsum, nl))
+    # Force a spread of regimes: pure snow, firn, and fully compacted ice.
+    OUT["subD"][::4, :] = rng.uniform(250.0, 480.0, OUT["subD"][::4, :].shape)
+    OUT["subD"][1::4, :] = C["Dice"]
+    OUT["subZ"] = np.full((gpsum, nl), grid["max_subZ"])
+    for n, split in enumerate(grid["split"]):
+        OUT["subZ"][:, split - 1 :] = (2.0 ** (n + 1)) * grid["max_subZ"]
+    OUT["subZ"][:, -1] = (2.0 ** len(grid["split"])) * grid["max_subZ"]
+    # Push some columns over the merge threshold and some under the split one.
+    OUT["subZ"][::5, grid["split"]] = grid["max_subZ"] * 0.5
+    OUT["subZ"][2::5, np.array(grid["split"]) - 2] = grid["max_subZ"] * 8.0
+    OUT["subW"] = rng.uniform(0.0, 3.0, (gpsum, nl))
+    OUT["subW"][::3, :] = 0.0
+    OUT["subS"] = rng.uniform(0.0, 2.0, (gpsum, nl))
+    OUT["subS"][1::3, :] = 0.0
+    OUT["surfH"] = rng.uniform(-1.0, 1.0, gpsum)
+    OUT["Tsurf"] = C["T0"] - rng.uniform(0.0, 15.0, gpsum)
+    # Conductivity / heat capacity diagnostics: INIT allocates these, and the
+    # GPU path writes the kernel results back into them in place.
+    OUT["subK"] = np.zeros((gpsum, nl))
+    OUT["subCeff"] = np.zeros((gpsum, nl))
+
+    # Surface energy balance results consumed by LOOP_SNOW.
+    OUT["melt"] = rng.uniform(0.0, 0.02, gpsum)
+    OUT["melt"][::6] = 0.0
+    # A couple of columns melt hard enough to force several grid shifts.
+    OUT["melt"][3::11] = 0.5
+    OUT["moist_deposition"] = rng.uniform(0.0, 1e-4, gpsum)
+    OUT["moist_sublimation"] = rng.uniform(0.0, 1e-4, gpsum)
+    OUT["moist_condensation"] = rng.uniform(0.0, 1e-4, gpsum)
+    OUT["moist_evaporation"] = rng.uniform(0.0, 1e-4, gpsum)
+    OUT["runoff_irr_deep_mean"] = rng.uniform(0.0, 1.0, gpsum)
+    # Deliberately NOT seeded here: "sumWinit", "cpi", "Dens_*" and "runoff_irr"
+    # are not created by INIT either, LOOP_SNOW produces them. Seeding them
+    # would hide a backend that only ever writes into an existing host array.
+
+    IN = {}
+    IN["T"] = C["T0"] - rng.uniform(-5.0, 25.0, gpsum)
+    IN["WS"] = rng.uniform(0.5, 15.0, gpsum)
+    IN["rain"] = rng.uniform(0.0, 5e-3, gpsum)
+    IN["snow"] = rng.uniform(0.0, 3e-3, gpsum)
+    # Some columns get enough snow for more than one grid shift.
+    IN["snow"][2::9] = 0.3
+    IN["snow"][::7] = 0.0
+    ys = rng.uniform(100.0, 900.0, gpsum)
+    IN["yearsnow"] = np.tile(ys[:, None], (1, nl))
+    IN["logyearsnow"] = np.tile(np.log(ys)[:, None], (1, nl))
+
+    return C, OUT, IN, dt, grid, phys
+
+
+def _deepcopy_state(OUT, IN):
+    copy = {k: (v.copy() if isinstance(v, np.ndarray) else v) for k, v in OUT.items()}
+    copy_in = {k: (v.copy() if isinstance(v, np.ndarray) else v) for k, v in IN.items()}
+    return copy, copy_in
+
+
+# Fields both backends must agree on. The subsurface grids and every LOOP_SNOW
+# output that leaves the module; --dump-reference compares a subset of these.
+_COMPARED = [
+    "subT",
+    "subD",
+    "subZ",
+    "subW",
+    "subS",
+    "subTmean",
+    "surfH",
+    "T_ice",
+    "runoff",
+    "runoff_surf",
+    "runoff_slush",
+    "runoff_irr",
+    "runoff_irr_deep",
+    "refr",
+    "refr_P",
+    "refr_S",
+    "refr_I",
+    "slushw",
+    "irrw",
+    "Dens_destr_metam",
+    "Dens_overb_pres",
+    "Dens_drift",
+]
+
+
+@unittest.skipUnless(_NUMBA and _CUDASIM, "requires numba with NUMBA_ENABLE_CUDASIM=1")
+class TestLoopSnowGPUMatchesNumPy(unittest.TestCase):
+    """The GPU backend must reproduce the NumPy backend, step for step."""
+
+    @classmethod
+    def setUpClass(cls):
+        from ebfm.core import LOOP_SNOW, compute_backend
+
+        cls.LOOP_SNOW = LOOP_SNOW
+        cls.compute_backend = compute_backend
+
+        # The drift-densification time scale divides by a gamma that underflows
+        # to zero in the deepest layers, giving tau = inf and a zero increment.
+        # The NumPy path wraps the same division in np.errstate(divide="ignore");
+        # under the CUDA simulator it surfaces as a Python RuntimeWarning, which
+        # a real device never raises.
+        warnings.filterwarnings("ignore", message="divide by zero encountered", category=RuntimeWarning)
+
+    def setUp(self):
+        self.compute_backend._backend = self.compute_backend.ComputeBackend.NUMPY
+
+    def tearDown(self):
+        self.compute_backend._backend = self.compute_backend.ComputeBackend.NUMPY
+
+    def _run(self, backend, steps):
+        """Run `steps` LOOP_SNOW timesteps on `backend` from a fixed state."""
+        C, OUT, IN, dt, grid, phys = _make_case()
+        self.compute_backend._backend = backend
+        for _ in range(steps):
+            # Fresh copies of the per-step forcing, so both backends see the
+            # same inputs even though LOOP_SNOW overwrites some of them.
+            _, IN_step = _deepcopy_state(OUT, IN)
+            self.LOOP_SNOW.main(C, OUT, IN_step, dt, grid, phys)
+        return OUT
+
+    def _assert_matches(self, ref, got, context):
+        for key in _COMPARED:
+            with self.subTest(field=key, context=context):
+                self.assertIn(key, ref, f"{key} missing from the NumPy result")
+                self.assertIn(key, got, f"{key} missing from the GPU result")
+                a = np.asarray(ref[key], dtype=np.float64)
+                b = np.asarray(got[key], dtype=np.float64)
+                self.assertEqual(a.shape, b.shape, f"{key}: shape mismatch")
+                if not np.allclose(a, b, atol=1e-12, rtol=1e-9, equal_nan=True):
+                    diff = np.abs(a - b)
+                    worst = np.unravel_index(np.nanargmax(diff), diff.shape)
+                    self.fail(
+                        f"{key} differs ({context}): max|diff|={np.nanmax(diff):.6e} "
+                        f"at {worst}, numpy={a[worst]!r}, gpu={b[worst]!r}"
+                    )
+
+    def test_single_step_matches_numpy(self):
+        ref = self._run(self.compute_backend.ComputeBackend.NUMPY, steps=1)
+        self.setUp()
+        got = self._run(self.compute_backend.ComputeBackend.GPU, steps=1)
+        self._assert_matches(ref, got, "1 step")
+
+    def test_multi_step_matches_numpy(self):
+        """Three steps: catches state that is not carried correctly on the device."""
+        ref = self._run(self.compute_backend.ComputeBackend.NUMPY, steps=3)
+        self.setUp()
+        got = self._run(self.compute_backend.ComputeBackend.GPU, steps=3)
+        self._assert_matches(ref, got, "3 steps")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core/test_loop_snow_gpu.py
+++ b/tests/core/test_loop_snow_gpu.py
@@ -165,13 +165,7 @@ _COMPARED = [
 # default configuration exercises exactly one branch of each, so the modes are
 # enumerated here instead.
 _SNOW_COMPACTION_MODES = ("firn_only", "firn+snow")
-# "uniform" is missing on purpose: there is no NumPy reference to compare
-# against, because that branch raises TypeError before it produces a result
-# (LOOP_SNOW.percolation_refreezing_and_storage() indexes `carrot` with
-# `: ind + 1`, where `ind` is a per-column array). The bug is on main and
-# predates the GPU backend, so mode 3 of the kernel stays unverified until it
-# is fixed.
-_PERCOLATION_MODES = ("bucket", "normal", "linear")
+_PERCOLATION_MODES = ("bucket", "normal", "linear", "uniform")
 
 
 @unittest.skipUnless(_NUMBA and _CUDASIM, "requires numba with NUMBA_ENABLE_CUDASIM=1")

--- a/tests/core/test_loop_snow_gpu.py
+++ b/tests/core/test_loop_snow_gpu.py
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: 2026 EBFM Authors
 #
 # SPDX-License-Identifier: BSD-3-Clause
+#
+# Content partially generated with the assistance of AI tools.
+# Claude Code: Opus 5
 
 """
 Correctness gate for the GPU backend of LOOP_SNOW.

--- a/tests/core/test_loop_snow_gpu.py
+++ b/tests/core/test_loop_snow_gpu.py
@@ -43,13 +43,16 @@ except ImportError:  # pragma: no cover, numba is an optional dependency
     _NUMBA = False
 
 
-def _make_case(gpsum=48, nl=50, seed=7):
+def _make_case(gpsum=48, nl=50, seed=7, snow_compaction="firn+snow", percolation="normal"):
     """Build a small but non-degenerate LOOP_SNOW state.
 
     The columns are randomised across the regimes the kernels branch on: snow
     and firn and solid ice densities, wet and dry layers, columns that gain
     enough snow to shift the grid down and columns that melt enough to shift it
     up, and layer thicknesses on both sides of the merge/split thresholds.
+
+    `snow_compaction` and `percolation` select the physics branch the kernels
+    take; see _SNOW_COMPACTION_MODES / _PERCOLATION_MODES below.
     """
     from ebfm.core import INIT
 
@@ -67,7 +70,7 @@ def _make_case(gpsum=48, nl=50, seed=7):
     # A few inactive columns, so the kernel's mask early-out is exercised.
     grid["mask"][:3] = 0
 
-    phys = {"snow_compaction": "firn+snow", "percolation": "normal"}
+    phys = {"snow_compaction": snow_compaction, "percolation": percolation}
     dt = 1.0 / 24.0
 
     OUT = {}
@@ -157,6 +160,19 @@ _COMPARED = [
     "Dens_drift",
 ]
 
+# The physics options the kernels switch on: _compaction_kernel_gpu takes the
+# snow_compaction branch, _percolation_kernel_gpu the percolation one. The
+# default configuration exercises exactly one branch of each, so the modes are
+# enumerated here instead.
+_SNOW_COMPACTION_MODES = ("firn_only", "firn+snow")
+# "uniform" is missing on purpose: there is no NumPy reference to compare
+# against, because that branch raises TypeError before it produces a result
+# (LOOP_SNOW.percolation_refreezing_and_storage() indexes `carrot` with
+# `: ind + 1`, where `ind` is a per-column array). The bug is on main and
+# predates the GPU backend, so mode 3 of the kernel stays unverified until it
+# is fixed.
+_PERCOLATION_MODES = ("bucket", "normal", "linear")
+
 
 @unittest.skipUnless(_NUMBA and _CUDASIM, "requires numba with NUMBA_ENABLE_CUDASIM=1")
 class TestLoopSnowGPUMatchesNumPy(unittest.TestCase):
@@ -182,9 +198,9 @@ class TestLoopSnowGPUMatchesNumPy(unittest.TestCase):
     def tearDown(self):
         self.compute_backend._backend = self.compute_backend.ComputeBackend.NUMPY
 
-    def _run(self, backend, steps):
+    def _run(self, backend, steps, **case):
         """Run `steps` LOOP_SNOW timesteps on `backend` from a fixed state."""
-        C, OUT, IN, dt, grid, phys = _make_case()
+        C, OUT, IN, dt, grid, phys = _make_case(**case)
         self.compute_backend._backend = backend
         for _ in range(steps):
             # Fresh copies of the per-step forcing, so both backends see the
@@ -221,6 +237,22 @@ class TestLoopSnowGPUMatchesNumPy(unittest.TestCase):
         self.setUp()
         got = self._run(self.compute_backend.ComputeBackend.GPU, steps=3)
         self._assert_matches(ref, got, "3 steps")
+
+    def test_physics_modes_match_numpy(self):
+        """Every snow_compaction / percolation branch of the kernels, one step each.
+
+        The other tests only ever run "firn+snow" and "normal", which leaves the
+        remaining kernel branches unexecuted.
+        """
+        for snow_compaction in _SNOW_COMPACTION_MODES:
+            for percolation in _PERCOLATION_MODES:
+                with self.subTest(snow_compaction=snow_compaction, percolation=percolation):
+                    case = {"snow_compaction": snow_compaction, "percolation": percolation}
+                    self.setUp()
+                    ref = self._run(self.compute_backend.ComputeBackend.NUMPY, steps=1, **case)
+                    self.setUp()
+                    got = self._run(self.compute_backend.ComputeBackend.GPU, steps=1, **case)
+                    self._assert_matches(ref, got, f"{snow_compaction}/{percolation}, 1 step")
 
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,17 @@ extras =
 commands =
     pytest tests/ -v --cov=src/ebfm --cov-report=term-missing
 
+[testenv:gpu-sim]
+description = Run the GPU backend against NumPy on numba's CUDA simulator (no GPU required)
+deps =
+    numba >= 0.62
+setenv =
+    # Must be set before numba is imported, hence a dedicated environment: in a
+    # full `pytest tests/` run another module may import numba first.
+    NUMBA_ENABLE_CUDASIM = 1
+commands =
+    pytest tests/core/test_loop_snow_gpu.py -v
+
 [testenv:examples]
 description = Run examples
 extras =


### PR DESCRIPTION
Adds `--with-gpu` (third compute backend next to NumPy and Numba). The compaction, heat conduction and percolation kernels of `LOOP_SNOW` can now run on the GPU (the rest stays on the host for the moment). Without the flag nothing changes: the NumPy and Numba paths are untouched.

Note: Depends on #147 (host-side LOOP_SNOW optimizations), this should be merged first.

## What it does

- `compute_backend.py` gains a `GPU` backend and `init_gpu()`, which runs a device smoke test before switching the backend (a missing CUDA/ROCm runtime fails at startup instead of mid-run).
- One kernel source for both vendors: NVIDIA via `numba.cuda`, AMD via numba-hip's `pose_as_cuda()`, which makes the same `@cuda.jit` kernels run on AMD GPUs. Detection is at import time (`--gpu-vendor {auto,nvidia,amd}`).
- `LOOP_SNOW_gpu_kernels.py` holds the kernels and `SnowDeviceState`, which keeps `subT/subD/subZ/subW/subS` on the device across compaction -> heat conduction -> percolation.
- `numba.cuda` is imported lazily inside the GPU branch, so NumPy/Numba users never pull in the GPU stack.
- New extra: `pip install ebfm[gpu]`. README documents the flags and the `CUDA_HOME` setup needed on Levante (Numba needs the CUDA runtime, not just the driver).

## Correctness

`tests/core/test_loop_snow_gpu.py` runs the snow model on the NumPy and the GPU backend from an identical state and requires agreement to `atol=1e-12, rtol=1e-9`. It uses numba's "CUDA simulator", so it needs no GPU and runs in CI
via the new `gpu-sim` tox environment. The simulator has to be enabled before numba is imported (Hence a dedicated environment rather than a flag on `tox -e unit`).

Additionally verified on A100 (Levante) against NumPy with `--dump-reference` on the MATLAB and Elmer meshes (everything within tolerance).

## Performance

This MR is about the capability, not the speed. At this stage the GPU path is not yet faster than `--with-numba`. The per-timestep transfers dominate. Optimizations follow in a separate MR on top of this one.

- [X] I ran the [pre-commit hooks](https://github.com/EBFMorg/EBFM?tab=readme-ov-file#developer-notes) and fixed all issues
- [X] I added an entry under *develop* in the [CHANGELOG.md](https://github.com/EBFMorg/EBFM/blob/main/CHANGELOG.md) (may be skipped for minor changes not observable for the user)
