### PR TITLE
Improve performance documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # develop
 
-* Moved performance and profiling sections out of `README.md` into `docs/Performance.md`, together with the GPU setup and CUDA runtime troubleshooting entry. https://github.com/EBFMorg/EBFM/pull/XXX
+* Moved performance and profiling sections out of `README.md` into `docs/Performance.md`, together with the GPU setup and CUDA runtime troubleshooting entry. https://github.com/EBFMorg/EBFM/pull/161
 * Removed the `uniform` percolation scheme (not used in practice, `normal` and `bucket` are typically chosen). `phys["percolation"]` now accepts `bucket`, `normal` and `linear`. Adapted tests. https://github.com/EBFMorg/EBFM/pull/160
 * Fixed `phys["percolation"] = "uniform"` raising `TypeError` on the first timestep in `LOOP_SNOW.py` (only in NumPy path). `test_loop_snow_percolation.py` added. https://github.com/EBFMorg/EBFM/pull/158
 * Introduced `--with-gpu` to offload the kernels compaction, heat conduction, percolation to a GPU via `numba.cuda` (NVIDIA) or `numba.hip` (AMD), with `--gpu-vendor {auto,nvidia,amd}` to select/guard the vendor. Mutually exclusive with `--with-numba`. Install via `pip install ebfm[gpu]`. https://github.com/EBFMorg/EBFM/pull/157

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # develop
 
+* Moved performance and profiling sections out of `README.md` into `docs/Performance.md`, together with the GPU setup and CUDA runtime troubleshooting entry. https://github.com/EBFMorg/EBFM/pull/XXX
 * Removed the `uniform` percolation scheme (not used in practice, `normal` and `bucket` are typically chosen). `phys["percolation"]` now accepts `bucket`, `normal` and `linear`. Adapted tests. https://github.com/EBFMorg/EBFM/pull/160
 * Fixed `phys["percolation"] = "uniform"` raising `TypeError` on the first timestep in `LOOP_SNOW.py` (only in NumPy path). `test_loop_snow_percolation.py` added. https://github.com/EBFMorg/EBFM/pull/158
 * Introduced `--with-gpu` to offload the kernels compaction, heat conduction, percolation to a GPU via `numba.cuda` (NVIDIA) or `numba.hip` (AMD), with `--gpu-vendor {auto,nvidia,amd}` to select/guard the vendor. Mutually exclusive with `--with-numba`. Install via `pip install ebfm[gpu]`. https://github.com/EBFMorg/EBFM/pull/157

--- a/README.md
+++ b/README.md
@@ -223,105 +223,8 @@ Note that it is necessary to provide a `--start-time` consistent with the given 
 
 ### Performance and Profiling Runs
 
-#### Installation for Performance Runs
-
-Install this branch with the performance dependencies:
-
-```sh
-pip install -e .[performance]
-```
-
-This additionally installs `numba` to run with multiple CPU-threads.
-
-#### Running EBFM with performance optimizations
-
-EBFM now includes several performance improvements and supports several options for performance testing and benchmarking:
-
-- Regular (NumPy) path:
-
-  The default run already includes some performance improvements. Run as usual:
-
-  ```sh
-  ebfm --matlab-mesh examples/dem_and_mask.mat
-  ```
-
-- Numba kernels:
-
-  To enable Numba-accelerated kernels, use the `--with-numba` flag. You can control the number of threads with `--numba-threads N` (replace `N` with the desired thread count):
-
-  ```sh
-  ebfm --matlab-mesh examples/dem_and_mask.mat --with-numba --numba-threads 2
-  ```
-
-  Note: If you use more than one thread, you must specify `--numba-threads`. In practice, 2 threads have shown the best performance so far, but optimal settings depend on your hardware and problem size. Feel free to experiment.
-
-- GPU offloading:
-
-  Install the GPU dependencies and use the `--with-gpu` flag to offload kernels from `LOOP_SNOW.py` to a GPU:
-
-  ```sh
-  pip install -e .[gpu]
-  ebfm --matlab-mesh examples/dem_and_mask.mat --with-gpu
-  ```
-
-  The same kernels run on NVIDIA (via `numba.cuda`) and on AMD (via `numba.hip`). The vendor is detected automatically. You can use `--gpu-vendor {auto,nvidia,amd}` to select or guard it explicitly. `--with-gpu` and `--with-numba` are mutually exclusive.
-
-  Note: on a cluster you usually have to load a CUDA/ROCm toolkit and point `CUDA_HOME` at it, otherwise Numba cannot compile the kernels even though the GPU itself is visible. See [CUDA runtime not found](#numba-does-not-find-the-cuda-runtime-cudais_available-is-false) in the troubleshooting section.
-
-  Before a long run you can verify the setup with:
-
-  ```sh
-  python -c "from numba import cuda; print(cuda.is_available())"
-  ```
-
-  At startup `--with-gpu` reports which stack and device it found, so you can check it went to the GPU you expected:
-
-  ```
-  [GPU] backend enabled (nvidia). Device: NVIDIA A100-SXM4-80GB  free=79.15 GiB  total=79.15 GiB
-  ```
-
-
-#### Timing Your Run
-
-To measure the total runtime, simply prepend your command with `time`:
-
-```sh
-time ebfm --matlab-mesh examples/dem_and_mask.mat --with-numba --numba-threads 2
-```
-
-#### Comparing Results
-
-A new script is provided to compare model output snapshots:
-
-- `tools/compare_snapshots.py` can be used to compare two output files (e.g., from different runs or configurations).
-
-To create a reference file for comparison, use the `--dump-reference` option at the end of your run:
-
-```sh
-ebfm --matlab-mesh examples/dem_and_mask.mat --dump-reference reference_run.npz
-```
-
-Then compare with:
-
-```sh
-python tools/compare_snapshots.py reference_run.npz new_run.npz
-```
-
-Note: If you use the random-forcing within EBFM in your testcases, make sure to additionally set the option `--random-seed`, as explained below.
-
-#### Diagnostics and Reproducibility
-
-- The option `--random-seed` was introduced to allow reproducible runs (especially if the random forcing in the example testcase is used). Set a fixed seed to ensure identical results for repeated runs (important for benchmarking and debugging):
-
-  ```sh
-  ebfm --matlab-mesh examples/dem_and_mask.mat --random-seed 42
-  ```
-
-- Use `--diagnostics` to print some diagnostics for a quick overview for every timestep:
-
-  ```sh
-  ebfm --matlab-mesh examples/dem_and_mask.mat --diagnostics
-  ```
+Multi-threaded Numba kernels (`--with-numba`), GPU offloading (`--with-gpu`), timing, output comparison and
+reproducibility options are described in [docs/Performance.md](docs/Performance.md).
 
 ### Coupled simulation
 
@@ -408,6 +311,8 @@ pytest -v tests/
 
 ## Troubleshooting
 
+Numba and GPU runtime problems are covered in [docs/Performance.md](docs/Performance.md#troubleshooting).
+
 ### `libnetcdf.so` not found at runtime
 
 *Problem:* `./icon_dummy.x: error while loading shared libraries: libnetcdf.so.15: cannot open shared object file: No such file or directory`
@@ -418,19 +323,6 @@ pytest -v tests/
 *Problem:* `./icon_dummy.x: error while loading shared libraries: libyaxt_c.so.1: cannot open shared object file: No such file or directory`
 
 *Solution:* `export LD_LIBRARY_PATH='$YAXT_INSTALL_DIR/lib/'
-
-### Numba does not find the CUDA runtime (`cuda.is_available()` is `False`)
-
-*Problem:* `--with-gpu` fails, or `python -c "from numba import cuda; print(cuda.is_available())"` prints `False`, even though the GPU is visible. Note that `cuda.detect()` and `nvidia-smi` can still report the device correctly: they only need the CUDA *driver*, while Numba additionally needs the CUDA *runtime* (`libnvvm`, `libcudart`) to compile kernels.
-
-*Solution:* Point `CUDA_HOME` at a CUDA toolkit installation and add its libraries to `LD_LIBRARY_PATH`. On Levante, for example:
-
-```sh
-export CUDA_HOME=/sw/spack-levante/nvhpc-22.5-v4oky3/Linux_x86_64/22.5/cuda/11.7
-export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$LD_LIBRARY_PATH
-```
-
-Afterwards `cuda.is_available()` should print `True`.
 
 ### `#include <proj.h>` not found when building the Elmer dummy
 

--- a/docs/Performance.md
+++ b/docs/Performance.md
@@ -1,0 +1,121 @@
+<!--
+SPDX-FileCopyrightText: 2026 EBFM Authors
+
+SPDX-License-Identifier: BSD-3-Clause
+-->
+
+# Performance and Profiling Runs
+
+## Installation for Performance Runs
+
+Install EBFM with the performance features:
+
+```sh
+pip install -e .[performance]
+```
+
+This additionally installs `numba` to run with multiple CPU-threads.
+
+## Running EBFM with performance optimizations
+
+EBFM now includes several performance improvements and supports several options for performance testing and benchmarking:
+
+- Regular (NumPy) path:
+
+  The default run already includes some performance improvements. Run as usual:
+
+  ```sh
+  ebfm --matlab-mesh examples/dem_and_mask.mat
+  ```
+
+- Numba kernels:
+
+  To enable Numba-accelerated kernels, use the `--with-numba` flag. You can control the number of threads with `--numba-threads N` (replace `N` with the desired thread count):
+
+  ```sh
+  ebfm --matlab-mesh examples/dem_and_mask.mat --with-numba --numba-threads 2
+  ```
+
+  Note: If you use more than one thread, you must specify `--numba-threads`. In practice, 2 threads have shown the best performance so far, but optimal settings depend on your hardware and problem size. Feel free to experiment.
+
+- GPU offloading:
+
+  Install the GPU dependencies and use the `--with-gpu` flag to offload kernels from `LOOP_SNOW.py` to a GPU:
+
+  ```sh
+  pip install -e .[gpu]
+  ebfm --matlab-mesh examples/dem_and_mask.mat --with-gpu
+  ```
+
+  The same kernels run on NVIDIA (via `numba.cuda`) and on AMD (via `numba.hip`). The vendor is detected automatically. You can use `--gpu-vendor {auto,nvidia,amd}` to select or guard it explicitly. `--with-gpu` and `--with-numba` are mutually exclusive.
+
+  Note: on a cluster you usually have to load a CUDA/ROCm toolkit and point `CUDA_HOME` at it, otherwise Numba cannot compile the kernels even though the GPU itself is visible. See [CUDA runtime not found](#numba-does-not-find-the-cuda-runtime-cudais_available-is-false) in the troubleshooting section.
+
+  Before a long run you can verify the setup with:
+
+  ```sh
+  python -c "from numba import cuda; print(cuda.is_available())"
+  ```
+
+  At startup `--with-gpu` reports which stack and device it found, so you can check it went to the GPU you expected:
+
+  ```
+  [GPU] backend enabled (nvidia). Device: NVIDIA A100-SXM4-80GB  free=79.15 GiB  total=79.15 GiB
+  ```
+
+## Timing Your Run
+
+To measure the total runtime, simply prepend your command with `time`:
+
+```sh
+time ebfm --matlab-mesh examples/dem_and_mask.mat --with-numba --numba-threads 2
+```
+
+## Comparing Results
+
+A script is provided to compare model output snapshots:
+
+- `tools/compare_snapshots.py` can be used to compare two output files (e.g., from different runs or configurations).
+
+To create a reference file for comparison, use the `--dump-reference` option at the end of your run:
+
+```sh
+ebfm --matlab-mesh examples/dem_and_mask.mat --dump-reference reference_run.npz
+```
+
+Then compare with:
+
+```sh
+python tools/compare_snapshots.py reference_run.npz new_run.npz
+```
+
+Note: If you use the random-forcing within EBFM in your testcases, make sure to additionally set the option `--random-seed`, as explained below.
+
+## Diagnostics and Reproducibility
+
+- The option `--random-seed` allows reproducible runs (especially if the random forcing in the example testcase is used). Set a fixed seed to ensure identical results for repeated runs (important for benchmarking and debugging):
+
+  ```sh
+  ebfm --matlab-mesh examples/dem_and_mask.mat --random-seed 42
+  ```
+
+- Use `--diagnostics` to print some diagnostics for a quick overview for every timestep:
+
+  ```sh
+  ebfm --matlab-mesh examples/dem_and_mask.mat --diagnostics
+  ```
+
+## Troubleshooting
+
+### Numba does not find the CUDA runtime (`cuda.is_available()` is `False`)
+
+*Problem:* `--with-gpu` fails, or `python -c "from numba import cuda; print(cuda.is_available())"` prints `False`, even though the GPU is visible. Note that `cuda.detect()` and `nvidia-smi` can still report the device correctly: they only need the CUDA *driver*, while Numba additionally needs the CUDA *runtime* (`libnvvm`, `libcudart`) to compile kernels.
+
+*Solution:* Point `CUDA_HOME` at a CUDA toolkit installation and add its libraries to `LD_LIBRARY_PATH`. On Levante, for example:
+
+```sh
+export CUDA_HOME=/sw/spack-levante/nvhpc-22.5-v4oky3/Linux_x86_64/22.5/cuda/11.7
+export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$LD_LIBRARY_PATH
+```
+
+Afterwards `cuda.is_available()` should print `True`.

--- a/docs/Performance.md
+++ b/docs/Performance.md
@@ -11,47 +11,16 @@ SPDX-License-Identifier: BSD-3-Clause
 Install EBFM with the performance features:
 
 ```sh
-pip install -e .[performance]
+pip install ebfm[performance]
 ```
 
 This additionally installs `numba` to run with multiple CPU-threads.
 
-## Running EBFM with performance optimizations
-
-EBFM offers several options for tuning performance on a given system and for testing and benchmarking it.
-
-### Numba kernels: `--with-numba`
-
-`--with-numba` runs the `LOOP_SNOW.py` kernels (compaction, heat conduction, percolation) as compiled,
-multi-threaded Numba kernels instead of NumPy array operations. Use it on a multi-core CPU when no GPU is available.
-It generally outperforms the NumPy path, the more clearly the larger the mesh and the longer the run.
-
-It is not on by default because `numba` is an optional dependency and the kernels compile on first use. A very short run can therefore spend more time compiling than it saves.
-
-Control the number of threads with `--numba-threads N` (replace `N` with the desired thread count):
+For GPU offloading, install the GPU dependencies instead:
 
 ```sh
-ebfm --matlab-mesh examples/dem_and_mask.mat --with-numba --numba-threads 2
+pip install ebfm[gpu]
 ```
-
-Note: If you use more than one thread, you must specify `--numba-threads`. In practice, 2 threads have shown the
-best performance so far, but optimal settings depend on your hardware and problem size. Feel free to experiment.
-
-### GPU offloading: `--with-gpu`
-
-You can use this option when the node you run on has a GPU: it offloads the same kernels to the device. How much that
-gains depends on the mesh size and the GPU, and for small meshes it is not necessarily faster than `--with-numba`.
-`--with-gpu` and `--with-numba` are alternative backends for those kernels and therefore mutually exclusive.
-
-Install the GPU dependencies and run with the `--with-gpu` flag:
-
-```sh
-pip install -e .[gpu]
-ebfm --matlab-mesh examples/dem_and_mask.mat --with-gpu
-```
-
-The same kernels run on NVIDIA (via `numba.cuda`) and on AMD (via `numba.hip`). The vendor is detected
-automatically. You can use `--gpu-vendor {auto,nvidia,amd}` to select or guard it explicitly.
 
 Note: on a cluster you usually have to load a CUDA/ROCm toolkit and point `CUDA_HOME` at it, otherwise Numba
 cannot compile the kernels even though the GPU itself is visible. See
@@ -64,15 +33,52 @@ python -c "from numba import cuda; print(cuda.is_available())"
 # expected output: True
 ```
 
-At startup `--with-gpu` reports which stack and device it found, so you can check it went to the GPU you expected:
+## Running EBFM with performance optimizations
+
+EBFM offers several options for tuning performance on a given system and for testing and benchmarking it.
+
+### Numba kernels: `--with-numba`
+
+The option `--with-numba` runs the `LOOP_SNOW.py` kernels (compaction, heat conduction, percolation) as compiled,
+multi-threaded Numba kernels instead of NumPy array operations. Use it on a multi-core CPU when no GPU is available.
+It generally outperforms the NumPy path, the more clearly the larger the mesh and the longer the run.
+
+It is not on by default because `numba` is an optional dependency and the kernels compile on first use. A very short run can therefore spend more time compiling than it saves.
+
+Control the number of threads with `--numba-threads N` (replace `N` with the desired thread count).
+
+**Example:** Run EBFM on the MATLAB example mesh with the Numba kernels on two threads:
+
+```sh
+ebfm --matlab-mesh examples/dem_and_mask.mat --with-numba --numba-threads 2
+```
+
+Note: If you use more than one thread, you must specify `--numba-threads`. In practice, 2 threads have shown the
+best performance so far, but optimal settings depend on your hardware and problem size. Feel free to experiment.
+
+### GPU offloading: `--with-gpu`
+
+You can use the option `--with-gpu` when the node you run on has a GPU: it offloads the same kernels to the device as for the option `--with-numba`. How much that
+gains depends on the mesh size and the GPU, and for small meshes it is not necessarily faster than `--with-numba`.
+The options `--with-gpu` and `--with-numba` tell EBFM to select alternative backends for those kernels and are therefore mutually exclusive.
+
+**Example:** Run EBFM on the MATLAB example mesh with the GPU kernels:
+
+```sh
+ebfm --matlab-mesh examples/dem_and_mask.mat --with-gpu
+```
+
+The same kernels run on NVIDIA and AMD GPUs, see `--gpu-vendor` in `ebfm --help`.
+
+When `--with-gpu` is set, EBFM will report at startup which vendor backend (`nvidia` or `amd`) and which device have been found, so you can check it went to the GPU you expected:
 
 ```
-[GPU] backend enabled (nvidia). Device: NVIDIA A100-SXM4-80GB  free=79.15 GiB  total=79.15 GiB
+[GPU] backend enabled (nvidia). Device: NVIDIA A100-SXM4-80GB  free=78.83 GiB  total=79.15 GiB
 ```
 
 ## Timing Your Run
 
-To measure the total runtime, simply prepend your command with
+To measure the total runtime prepend your command with
 [`time`](https://www.gnu.org/software/bash/manual/bash.html#Pipelines):
 
 ```sh
@@ -105,7 +111,7 @@ Then compare with:
 python tools/compare_snapshots.py reference_run.npz new_run.npz
 ```
 
-Note: If you use the random-forcing within EBFM in your testcases, make sure to additionally set the option `--random-seed`, as explained below.
+Note: uncoupled runs (such as the example testcase) generate their climate forcing randomly, so make sure to additionally set the option `--random-seed`, as explained below.
 
 ## Diagnostics and Reproducibility
 
@@ -115,10 +121,10 @@ Note: If you use the random-forcing within EBFM in your testcases, make sure to 
   ebfm --matlab-mesh examples/dem_and_mask.mat --random-seed 42
   ```
 
-- Use `--diagnostics` to print some diagnostics for a quick overview for every timestep:
+- Use `--print-diagnostics` to print some diagnostics for a quick overview for every timestep:
 
   ```sh
-  ebfm --matlab-mesh examples/dem_and_mask.mat --diagnostics
+  ebfm --matlab-mesh examples/dem_and_mask.mat --print-diagnostics
   ```
 
 ## Troubleshooting

--- a/docs/Performance.md
+++ b/docs/Performance.md
@@ -18,64 +18,80 @@ This additionally installs `numba` to run with multiple CPU-threads.
 
 ## Running EBFM with performance optimizations
 
-EBFM now includes several performance improvements and supports several options for performance testing and benchmarking:
+EBFM offers several options for tuning performance on a given system and for testing and benchmarking it.
 
-- Regular (NumPy) path:
+### Numba kernels: `--with-numba`
 
-  The default run already includes some performance improvements. Run as usual:
+`--with-numba` runs the `LOOP_SNOW.py` kernels (compaction, heat conduction, percolation) as compiled,
+multi-threaded Numba kernels instead of NumPy array operations. Use it on a multi-core CPU when no GPU is available.
+It generally outperforms the NumPy path, the more clearly the larger the mesh and the longer the run.
 
-  ```sh
-  ebfm --matlab-mesh examples/dem_and_mask.mat
-  ```
+It is not on by default because `numba` is an optional dependency and the kernels compile on first use. A very short run can therefore spend more time compiling than it saves.
 
-- Numba kernels:
+Control the number of threads with `--numba-threads N` (replace `N` with the desired thread count):
 
-  To enable Numba-accelerated kernels, use the `--with-numba` flag. You can control the number of threads with `--numba-threads N` (replace `N` with the desired thread count):
+```sh
+ebfm --matlab-mesh examples/dem_and_mask.mat --with-numba --numba-threads 2
+```
 
-  ```sh
-  ebfm --matlab-mesh examples/dem_and_mask.mat --with-numba --numba-threads 2
-  ```
+Note: If you use more than one thread, you must specify `--numba-threads`. In practice, 2 threads have shown the
+best performance so far, but optimal settings depend on your hardware and problem size. Feel free to experiment.
 
-  Note: If you use more than one thread, you must specify `--numba-threads`. In practice, 2 threads have shown the best performance so far, but optimal settings depend on your hardware and problem size. Feel free to experiment.
+### GPU offloading: `--with-gpu`
 
-- GPU offloading:
+You can use this option when the node you run on has a GPU: it offloads the same kernels to the device. How much that
+gains depends on the mesh size and the GPU, and for small meshes it is not necessarily faster than `--with-numba`.
+`--with-gpu` and `--with-numba` are alternative backends for those kernels and therefore mutually exclusive.
 
-  Install the GPU dependencies and use the `--with-gpu` flag to offload kernels from `LOOP_SNOW.py` to a GPU:
+Install the GPU dependencies and run with the `--with-gpu` flag:
 
-  ```sh
-  pip install -e .[gpu]
-  ebfm --matlab-mesh examples/dem_and_mask.mat --with-gpu
-  ```
+```sh
+pip install -e .[gpu]
+ebfm --matlab-mesh examples/dem_and_mask.mat --with-gpu
+```
 
-  The same kernels run on NVIDIA (via `numba.cuda`) and on AMD (via `numba.hip`). The vendor is detected automatically. You can use `--gpu-vendor {auto,nvidia,amd}` to select or guard it explicitly. `--with-gpu` and `--with-numba` are mutually exclusive.
+The same kernels run on NVIDIA (via `numba.cuda`) and on AMD (via `numba.hip`). The vendor is detected
+automatically. You can use `--gpu-vendor {auto,nvidia,amd}` to select or guard it explicitly.
 
-  Note: on a cluster you usually have to load a CUDA/ROCm toolkit and point `CUDA_HOME` at it, otherwise Numba cannot compile the kernels even though the GPU itself is visible. See [CUDA runtime not found](#numba-does-not-find-the-cuda-runtime-cudais_available-is-false) in the troubleshooting section.
+Note: on a cluster you usually have to load a CUDA/ROCm toolkit and point `CUDA_HOME` at it, otherwise Numba
+cannot compile the kernels even though the GPU itself is visible. See
+[CUDA runtime not found](#numba-does-not-find-the-cuda-runtime-cudais_available-is-false) below.
 
-  Before a long run you can verify the setup with:
+It is recommended to verify your cuda setup by running:
 
-  ```sh
-  python -c "from numba import cuda; print(cuda.is_available())"
-  ```
+```sh
+python -c "from numba import cuda; print(cuda.is_available())"
+# expected output: True
+```
 
-  At startup `--with-gpu` reports which stack and device it found, so you can check it went to the GPU you expected:
+At startup `--with-gpu` reports which stack and device it found, so you can check it went to the GPU you expected:
 
-  ```
-  [GPU] backend enabled (nvidia). Device: NVIDIA A100-SXM4-80GB  free=79.15 GiB  total=79.15 GiB
-  ```
+```
+[GPU] backend enabled (nvidia). Device: NVIDIA A100-SXM4-80GB  free=79.15 GiB  total=79.15 GiB
+```
 
 ## Timing Your Run
 
-To measure the total runtime, simply prepend your command with `time`:
+To measure the total runtime, simply prepend your command with
+[`time`](https://www.gnu.org/software/bash/manual/bash.html#Pipelines):
 
 ```sh
 time ebfm --matlab-mesh examples/dem_and_mask.mat --with-numba --numba-threads 2
 ```
 
+The shell then prints the wall-clock (`real`) and CPU times, for example:
+
+```
+real    1m12.771s
+user    2m18.492s
+sys     0m2.113s
+```
+
+For benchmarking, compare `real` between runs: `user` exceeding it only means several threads ran in parallel.
+
 ## Comparing Results
 
-A script is provided to compare model output snapshots:
-
-- `tools/compare_snapshots.py` can be used to compare two output files (e.g., from different runs or configurations).
+The script `tools/compare_snapshots.py` allows to compare two output files (e.g., from different runs or configurations).
 
 To create a reference file for comparison, use the `--dump-reference` option at the end of your run:
 
@@ -118,4 +134,9 @@ export CUDA_HOME=/sw/spack-levante/nvhpc-22.5-v4oky3/Linux_x86_64/22.5/cuda/11.7
 export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$LD_LIBRARY_PATH
 ```
 
-Afterwards `cuda.is_available()` should print `True`.
+Afterwards the check above should succeed:
+
+```sh
+python -c "from numba import cuda; print(cuda.is_available())"
+# expected output: True
+```

--- a/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
+++ b/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
@@ -35,6 +35,7 @@ are never launched.
 """
 
 import math
+import warnings
 
 import numpy as np
 
@@ -860,11 +861,23 @@ def probe_gpu_device() -> dict:
         return {"available": False, "reason": f"failed to query device memory: {exc}"}
 
     # Round-trip test: allocate 32 ones, double on GPU, assert result == 2.
+    # Imported here and not at module level: numba is only guaranteed to be
+    # importable once init_gpu() has checked _GPU_AVAILABLE, which it does
+    # before calling this function.
+    from numba.core.errors import NumbaPerformanceWarning
+
     host_arr = np.ones(32, dtype=np.float64)
     try:
-        d_arr = cuda.to_device(host_arr)
-        _gpu_probe_kernel[4, 8](d_arr)  # 4 blocks x 8 threads = 32 threads
-        result = d_arr.copy_to_host()
+        # numba warns about grids below 128 blocks. The probe is deliberately
+        # tiny, so that warning says nothing about the real kernels, but it would
+        # show up in every --with-gpu run log. Suppressed for this launch only;
+        # the warning is raised when the launch is configured (`[4, 8]`), so that
+        # has to happen inside the block as well.
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=NumbaPerformanceWarning)
+            d_arr = cuda.to_device(host_arr)
+            _gpu_probe_kernel[4, 8](d_arr)  # 4 blocks x 8 threads = 32 threads
+            result = d_arr.copy_to_host()
     except Exception as exc:
         return {"available": False, "reason": f"GPU kernel launch failed: {exc}"}
 

--- a/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
+++ b/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
@@ -861,18 +861,13 @@ def probe_gpu_device() -> dict:
         return {"available": False, "reason": f"failed to query device memory: {exc}"}
 
     # Round-trip test: allocate 32 ones, double on GPU, assert result == 2.
-    # Imported here and not at module level: numba is only guaranteed to be
-    # importable once init_gpu() has checked _GPU_AVAILABLE, which it does
-    # before calling this function.
     from numba.core.errors import NumbaPerformanceWarning
 
     host_arr = np.ones(32, dtype=np.float64)
     try:
-        # numba warns about grids below 128 blocks. The probe is deliberately
-        # tiny, so that warning says nothing about the real kernels, but it would
-        # show up in every --with-gpu run log. Suppressed for this launch only;
-        # the warning is raised when the launch is configured (`[4, 8]`), so that
-        # has to happen inside the block as well.
+        # numba warns about the probe's tiny grid: suppressed for this launch only,
+        # and `[4, 8]` has to stay nside the block because that is where the warning
+        # is raised.
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=NumbaPerformanceWarning)
             d_arr = cuda.to_device(host_arr)


### PR DESCRIPTION
Follow-up to #157, documentation only, no code changes.

The `README` had grown a large performance section: Numba threading, GPU offloading, timing, snapshot comparison, reproducibility flags, plus a GPU-specific troubleshooting entry. All of that was moved into `docs/Performance.md` so the README stays an overview.

# Author's Todos

- [x] I ran the [pre-commit hooks](https://github.com/EBFMorg/EBFM?tab=readme-ov-file#developer-notes) and fixed all issues
- [x] I added an entry under *develop* in the [CHANGELOG.md](https://github.com/EBFMorg/EBFM/blob/main/CHANGELOG.md) (may be skipped for minor changes not observable for the user)
