### PR TITLE
GPU performance optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # develop
 
+* `--with-gpu` now runs all of `LOOP_SNOW` on the device: `snowfall_and_deposition`, `melt_sublimation` and `layer_merging_and_splitting` have CUDA kernels too, so the subsurface state (`subT`, `subD`, `subZ`, `subW`, `subS`, `subTmean`, `surfH`) is uploaded once per run and stays resident across timesteps instead of round-tripping twice per timestep. Per-step transfers are now the `(gpsum,)` forcing and result vectors plus the few layers host code reads in between; the full grids move only for a netCDF sample, the restart file and `--dump-reference`. `LOOP_SNOW.sync_gpu_state()` copies them back on demand and replaces `flush_gpu_diagnostics()`.
 * `LOOP_EBM` evaluates the GHF conductivity on the top two subsurface layers instead of the whole grid (only those enter `GHF_C`), and `LOOP_write_to_file` reads `sample`-type variables only on the timesteps that record one. Both are bit-identical for every backend.
 
 # v0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # develop
 
-* `--with-gpu` now runs all of `LOOP_SNOW` on the device: `snowfall_and_deposition`, `melt_sublimation` and `layer_merging_and_splitting` have CUDA kernels too, so the subsurface state (`subT`, `subD`, `subZ`, `subW`, `subS`, `subTmean`, `surfH`) is uploaded once per run and stays resident across timesteps instead of round-tripping twice per timestep. Per-step transfers are now the `(gpsum,)` forcing and result vectors plus the few layers host code reads in between; the full grids move only for a netCDF sample, the restart file and `--dump-reference`. `LOOP_SNOW.sync_gpu_state()` copies them back on demand and replaces `flush_gpu_diagnostics()`.
-* `LOOP_EBM` evaluates the GHF conductivity on the top two subsurface layers instead of the whole grid (only those enter `GHF_C`), and `LOOP_write_to_file` reads `sample`-type variables only on the timesteps that record one. Both are bit-identical for every backend.
+* `--with-gpu` now runs all of `LOOP_SNOW` on the device and keeps the subsurface state resident across timesteps, instead of round-tripping it twice per timestep. Per-step transfers are down to the `(gpsum,)` forcing and result vectors; `LOOP_SNOW.sync_gpu_state()` copies the full grids back when output, restart or `--dump-reference` needs them.
+* `LOOP_EBM` evaluates the GHF conductivity on the top two subsurface layers only, and `LOOP_write_to_file` reads `sample`-type variables only on timesteps that record one. Bit-identical for every backend.
 
 # v0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ SPDX-FileCopyrightText: 2025 EBFM Authors
 SPDX-License-Identifier: CC-BY-4.0
 -->
 
+# develop
+
+* `LOOP_EBM` evaluates the GHF conductivity on the top two subsurface layers instead of the whole grid (only those enter `GHF_C`), and `LOOP_write_to_file` reads `sample`-type variables only on the timesteps that record one. Both are bit-identical for every backend.
+
 # v0.7.0
 
 * Moved performance and profiling sections out of `README.md` into `docs/Performance.md`, together with the GPU setup and CUDA runtime troubleshooting entry. https://github.com/EBFMorg/EBFM/pull/161

--- a/src/ebfm/core/LOOP_EBM.py
+++ b/src/ebfm/core/LOOP_EBM.py
@@ -52,7 +52,13 @@ def main(C, OUT, IN, time2, grid, cpl: Coupler) -> dict:
         LWin = LOOP_EBM_LWin.main(C, IN)
 
     SWout, OUT = LOOP_EBM_SWout.main(C, time2, OUT, SWin)
-    GHF_k = 0.138 - 1.01e-3 * OUT["subD"] + 3.233e-6 * OUT["subD"] ** 2
+    # Only the top two layers enter GHF_C, and LOOP_EBM_GHF ignores GHF_k
+    # entirely, so the effective conductivity is evaluated on those two layers
+    # instead of the whole subsurface grid. Same values, and it lets the GPU
+    # backend keep subD resident on the device: LOOP_SNOW copies back only the
+    # layers read here (see LOOP_SNOW.sync_gpu_state).
+    subD_top = OUT["subD"][:, :2]
+    GHF_k = 0.138 - 1.01e-3 * subD_top + 3.233e-6 * subD_top**2
     GHF_C = (GHF_k[:, 0] * OUT["subZ"][:, 0] + 0.5 * GHF_k[:, 1] * OUT["subZ"][:, 1]) / (
         OUT["subZ"][:, 0] + 0.5 * OUT["subZ"][:, 1]
     ) ** 2

--- a/src/ebfm/core/LOOP_SNOW.py
+++ b/src/ebfm/core/LOOP_SNOW.py
@@ -1013,9 +1013,11 @@ def main(C, OUT, IN, dt: float, grid, phys):
         # state is uploaded once here and downloaded once after percolation,
         # instead of round-tripping in each sub-step.
         # Imported here so only GPU runs pull in numba.cuda.
-        from .LOOP_SNOW_gpu_kernels import SnowDeviceState
+        # The device buffers are allocated once per run and reused; only this
+        # timestep's values are uploaded.
+        from .LOOP_SNOW_gpu_kernels import get_device_state
 
-        gpu_state = SnowDeviceState(
+        gpu_state = get_device_state(
             OUT["subT"],
             OUT["subD"],
             OUT["subZ"],

--- a/src/ebfm/core/LOOP_SNOW.py
+++ b/src/ebfm/core/LOOP_SNOW.py
@@ -35,23 +35,29 @@ _MIN_LAYER_THICKNESS = 1e-17
 logger = logging.getLogger(__name__)
 
 
-def flush_gpu_diagnostics(OUT):
+def sync_gpu_state(OUT):
     """
-    Copy device-resident diagnostics back into OUT.
+    Copy the device-resident subsurface state back into OUT.
 
-    On the GPU backend these fields stay on the device during the time loop,
-    because no host code reads them there:
+    On the GPU backend LOOP_SNOW runs entirely on the device and the state
+    stays there across timesteps, so between two LOOP_SNOW calls these OUT
+    entries are stale:
 
-        subTmean, Dens_destr_metam, Dens_overb_pres, Dens_drift, subK, subCeff
+        subT, subD, subZ, subW, subS   (except the layers listed below)
+        subTmean, subK, subCeff
+        Dens_destr_metam, Dens_overb_pres, Dens_drift
+        sumWinit, Dfreshsnow, Dfreshsnow_T, Dfreshsnow_W, cpi
 
-    Call this before the values are actually used: creating a restart file or
-    dumping a reference snapshot. No-op for the NumPy and Numba backends.
+    What *is* kept current every timestep is only what host code reads before
+    the next LOOP_SNOW call: subD[:, :2], subZ[:, :2], subT[:, 1], T_ice,
+    surfH, all_ice_column and the (gpsum,) runoff / refreezing vectors.
 
-    NOTE: if new code starts reading any of the fields listed above, it must
-    call this first, otherwise it will see stale values on the GPU backend.
-    Do not call it once per timestep (e.g. next to LOOP_write_to_file, which
-    does not read these fields) -- that would copy six full grids per step and
-    defeat the purpose.
+    Call this before any full-grid read -- writing a netCDF sample, creating a
+    restart file, dumping a reference snapshot. No-op for the NumPy and Numba
+    backends.
+
+    NOTE: this copies eleven full grids, so do not call it unconditionally once
+    per timestep -- that would undo the residency it exists to support.
 
     Parameters:
         OUT (dict): Output variables to update in place.
@@ -59,9 +65,9 @@ def flush_gpu_diagnostics(OUT):
     if get_backend() != ComputeBackend.GPU:
         return
 
-    from .LOOP_SNOW_gpu_kernels import flush_device_diagnostics
+    from .LOOP_SNOW_gpu_kernels import sync_device_state
 
-    flush_device_diagnostics(OUT)
+    sync_device_state(OUT)
 
 
 def main(C, OUT, IN, dt: float, grid, phys):
@@ -92,8 +98,15 @@ def main(C, OUT, IN, dt: float, grid, phys):
 
     logger.debug("Starting LOOP_SNOW...")
 
+    def _compaction_mode():
+        """Numeric snow_compaction selector shared by the Numba and GPU kernels."""
+        mode = {"firn_only": 0, "firn+snow": 1}.get(phys["snow_compaction"], -1)
+        if mode < 0:
+            raise ValueError(f"unknown snow_compaction={phys['snow_compaction']!r}")
+        return mode
+
     @profile
-    def snowfall_and_deposition():
+    def snowfall_and_deposition(gpu=None):
         """
         Calculate snowfall and deposition and shift vertical grid accordingly
         """
@@ -101,6 +114,13 @@ def main(C, OUT, IN, dt: float, grid, phys):
         max_subZ = grid["max_subZ"]
         gpsum = grid["gpsum"]
         nl = grid["nl"]
+
+        if gpu is not None:
+            # GPU: fresh-snow density and the grid shift run on the resident
+            # device arrays; the shift loop is driven from here via a 4-byte
+            # device flag (see SnowDeviceState.snowfall_and_deposition).
+            gpu.snowfall_and_deposition(C, grid, _compaction_mode())
+            return _SUCCESS
 
         # Fresh snow density calculations
         if phys["snow_compaction"] == "firn+snow":
@@ -197,10 +217,20 @@ def main(C, OUT, IN, dt: float, grid, phys):
         return _SUCCESS
 
     @profile
-    def melt_sublimation():
+    def melt_sublimation(gpu=None):
         """
         Calculate melt and sublimation and shift vertical grid accordingly
         """
+
+        if gpu is not None:
+            # GPU: mass removal and the grid shift run on the resident device
+            # arrays; sumWinit is produced there for compaction to consume.
+            if grid["doubledepth"] == 1:
+                bottom_thickness = 2.0 ** len(grid["split"]) * grid["max_subZ"]
+            else:
+                bottom_thickness = grid["max_subZ"]
+            gpu.melt_sublimation(bottom_thickness)
+            return _SUCCESS
 
         # Initialize variables
         OUT["sumWinit"] = np.sum(OUT["subW"], axis=1)
@@ -317,9 +347,7 @@ def main(C, OUT, IN, dt: float, grid, phys):
         # Numba / GPU kernel path:
         backend = get_backend()
         if backend in (ComputeBackend.NUMBA, ComputeBackend.GPU):
-            _mode = {"firn_only": 0, "firn+snow": 1}.get(phys["snow_compaction"], -1)
-            if _mode < 0:
-                raise ValueError(f"_compaction_kernel: unknown snow_compaction={phys['snow_compaction']!r}")
+            _mode = _compaction_mode()
             _tau_drift = 48 * 2 * SECONDS_PER_HOUR
             if gpu is not None:
                 # GPU: kernel launched on the resident device arrays. The
@@ -910,7 +938,7 @@ def main(C, OUT, IN, dt: float, grid, phys):
         return _SUCCESS
 
     @profile
-    def layer_merging_and_splitting():
+    def layer_merging_and_splitting(gpu=None):
         """
         Layer merging and splitting
         """
@@ -922,6 +950,12 @@ def main(C, OUT, IN, dt: float, grid, phys):
         mask1 = grid["mask"] == 1
         nsplit = len(grid["split"])
         top_thickness = (2.0**nsplit) * max_subZ
+
+        if gpu is not None:
+            # GPU: one thread per column walks the split levels itself, so the
+            # np.flatnonzero index sets and the five row snapshots disappear.
+            gpu.layer_merging_and_splitting(max_subZ, top_thickness)
+            return _SUCCESS
 
         for n in range(nsplit):  # Iterate through split points
             split = grid["split"][n]
@@ -1033,40 +1067,35 @@ def main(C, OUT, IN, dt: float, grid, phys):
 
         return _SUCCESS
 
-    snowfall_and_deposition()
-    melt_sublimation()
     if get_backend() == ComputeBackend.GPU:
-        # Resident-state core: subT/subD/subZ/subW/subS stay on the device
-        # across compaction -> heat conduction -> percolation. The subsurface
-        # state is uploaded once here and downloaded once after percolation,
-        # instead of round-tripping in each sub-step.
+        # Fully resident core: subT/subD/subZ/subW/subS/subTmean/surfH live on
+        # the device for the whole run. Every compute sub-step below dispatches
+        # its kernel launches to the device state, so nothing round-trips
+        # between sub-steps and nothing is re-uploaded between timesteps. Each
+        # function keeps its usual host-side glue, so results match the
+        # NumPy/Numba paths.
         # Imported here so only GPU runs pull in numba.cuda.
-        # The device buffers are allocated once per run and reused; only this
-        # timestep's values are uploaded.
         from .LOOP_SNOW_gpu_kernels import get_device_state
 
-        gpu_state = get_device_state(
-            OUT["subT"],
-            OUT["subD"],
-            OUT["subZ"],
-            OUT["subW"],
-            OUT["subS"],
-            OUT["subTmean"],
-            OUT["surfH"],
-            IN["logyearsnow"],
-            IN["yearsnow"],
-            IN["WS"],
-            OUT["Tsurf"],
-            OUT["sumWinit"],
-        )
+        gpu_state = get_device_state(OUT, IN, grid)
+        snowfall_and_deposition(gpu_state)
+        melt_sublimation(gpu_state)
         compaction(gpu_state)
         heat_conduction(gpu_state)
         percolation_refreezing_and_storage(gpu_state)
-        gpu_state.download(OUT)
-    else:
-        compaction()
-        heat_conduction()
-        percolation_refreezing_and_storage()
+        layer_merging_and_splitting(gpu_state)
+        # Only the (gpsum,) vectors and the few layers the host reads before
+        # the next LOOP_SNOW call come back; see download_boundary(). It also
+        # sets OUT["T_ice"] straight from the deepest device layer.
+        gpu_state.download_boundary(OUT, C["Dice"])
+        runoff()
+        return OUT
+
+    snowfall_and_deposition()
+    melt_sublimation()
+    compaction()
+    heat_conduction()
+    percolation_refreezing_and_storage()
     layer_merging_and_splitting()
     runoff()
     OUT["T_ice"] = OUT["subT"][:, -1]

--- a/src/ebfm/core/LOOP_SNOW.py
+++ b/src/ebfm/core/LOOP_SNOW.py
@@ -271,11 +271,13 @@ def main(C, OUT, IN, dt: float, grid, phys):
 
         # Pre-zero diagnostic arrays once
         # Avoids np.zeros_like allocation for each array on every timestep.
+        # On the GPU path the kernel zeroes them on the device, so only the
+        # host buffers (download targets) have to exist here.
         _dshape = OUT["subD"].shape
         for _key in ("Dens_destr_metam", "Dens_overb_pres", "Dens_drift"):
             if _key not in OUT or OUT[_key].shape != _dshape:
                 OUT[_key] = np.zeros(_dshape)
-            else:
+            elif gpu is None:
                 OUT[_key].fill(0.0)
 
         # runoff_irr is written by the kernel. Ensure it exists before it reads.

--- a/src/ebfm/core/LOOP_SNOW.py
+++ b/src/ebfm/core/LOOP_SNOW.py
@@ -294,9 +294,6 @@ def main(C, OUT, IN, dt: float, grid, phys):
                 # GPU: kernel launched on the resident device arrays. The
                 # pre-compaction subD/subZ snapshot is taken on-device.
                 gpu.compaction(
-                    OUT["Dens_destr_metam"],
-                    OUT["Dens_overb_pres"],
-                    OUT["Dens_drift"],
                     dt_yearfrac,
                     dt_seconds,
                     dt,

--- a/src/ebfm/core/LOOP_SNOW.py
+++ b/src/ebfm/core/LOOP_SNOW.py
@@ -35,6 +35,35 @@ _MIN_LAYER_THICKNESS = 1e-17
 logger = logging.getLogger(__name__)
 
 
+def flush_gpu_diagnostics(OUT):
+    """
+    Copy device-resident diagnostics back into OUT.
+
+    On the GPU backend these fields stay on the device during the time loop,
+    because no host code reads them there:
+
+        subTmean, Dens_destr_metam, Dens_overb_pres, Dens_drift, subK, subCeff
+
+    Call this before the values are actually used: creating a restart file or
+    dumping a reference snapshot. No-op for the NumPy and Numba backends.
+
+    NOTE: if new code starts reading any of the fields listed above, it must
+    call this first, otherwise it will see stale values on the GPU backend.
+    Do not call it once per timestep (e.g. next to LOOP_write_to_file, which
+    does not read these fields) -- that would copy six full grids per step and
+    defeat the purpose.
+
+    Parameters:
+        OUT (dict): Output variables to update in place.
+    """
+    if get_backend() != ComputeBackend.GPU:
+        return
+
+    from .LOOP_SNOW_gpu_kernels import flush_device_diagnostics
+
+    flush_device_diagnostics(OUT)
+
+
 def main(C, OUT, IN, dt: float, grid, phys):
     """
     Implementation of the multi-layer snow and firn model.

--- a/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
+++ b/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
@@ -108,8 +108,8 @@ def _compaction_kernel_gpu(
     subW,
     subTmean,
     subD_old,
-    logyearsnow,
-    yearsnow,
+    logyearsnow,  # (gpsum,) - layer-invariant on the host, so kept 1-D here
+    yearsnow,  # (gpsum,)
     WS,
     Dens_destr_metam,
     Dens_overb_pres,
@@ -146,11 +146,11 @@ def _compaction_kernel_gpu(
         cond_firn_k = (compaction_mode == 0) or (subD[k, i] >= Dfirn)
         if cond_firn_k:
             if subD[k, i] < 550.0:
-                grav_const = 0.07 * _fmax(1.435 - 0.151 * logyearsnow[k, i], 0.25)
+                grav_const = 0.07 * _fmax(1.435 - 0.151 * logyearsnow[i], 0.25)
             else:
-                grav_const = 0.03 * _fmax(2.366 - 0.293 * logyearsnow[k, i], 0.25)
+                grav_const = 0.03 * _fmax(2.366 - 0.293 * logyearsnow[i], 0.25)
             temp_factor = math.exp(-Ec / (rd * subT[k, i]) + Eg / (rd * subTmean[k, i]))
-            firn_inc = dt_yearfrac * grav_const * yearsnow[k, i] * g * (Dice - subD[k, i]) * temp_factor
+            firn_inc = dt_yearfrac * grav_const * yearsnow[i] * g * (Dice - subD[k, i]) * temp_factor
             subD[k, i] += firn_inc
 
     # ------ 2. SEASONAL SNOW COMPACTION ------ #
@@ -638,8 +638,11 @@ class SnowDeviceState:
         self.surfH = cuda.device_array((gpsum,), dtype=np.float64)
 
         # Per-step inputs (read-only on the device).
-        self.logyearsnow = cuda.device_array((nl, gpsum), dtype=np.float64)
-        self.yearsnow = cuda.device_array((nl, gpsum), dtype=np.float64)
+        # logyearsnow / yearsnow are np.tile(x[:, None], (1, nl)) on the host,
+        # i.e. identical for every layer. Keep only the (gpsum,) vector on the
+        # device: 3 MB per step instead of 149 MB.
+        self.logyearsnow = cuda.device_array((gpsum,), dtype=np.float64)
+        self.yearsnow = cuda.device_array((gpsum,), dtype=np.float64)
         self.WS = cuda.device_array((gpsum,), dtype=np.float64)
         self.Tsurf = cuda.device_array((gpsum,), dtype=np.float64)
         self.sumWinit = cuda.device_array((gpsum,), dtype=np.float64)
@@ -706,8 +709,9 @@ class SnowDeviceState:
         self._upload_2d(self.subW, subW)
         self._upload_2d(self.subS, subS)
         self._upload_2d(self.subTmean, subTmean)
-        self._upload_2d(self.logyearsnow, logyearsnow)
-        self._upload_2d(self.yearsnow, yearsnow)
+        # Layer-invariant: upload a single column instead of the tiled grid.
+        self.logyearsnow.copy_to_device(np.ascontiguousarray(logyearsnow[:, 0]))
+        self.yearsnow.copy_to_device(np.ascontiguousarray(yearsnow[:, 0]))
         # 1-D per-column arrays need no transpose.
         self.surfH.copy_to_device(surfH)
         self.WS.copy_to_device(WS)
@@ -879,13 +883,10 @@ class SnowDeviceState:
         OUT["irrw"] = self.irrw.copy_to_host()
         OUT["refr"] = OUT["refr_P"] + OUT["refr_S"] + OUT["refr_I"]
 
-        # subK / subCeff are the post-compaction conductivity and heat capacity
-        # (from the prep kernel), matching the NumPy path's pre-heat-solve
-        # values. cpi is a diagnostic recomputed from the final subT; as in the
-        # per-call GPU path this differs from NumPy only at the last refreezing
-        # sub-step and is not consumed downstream.
-        self._download_2d(self.kk, OUT["subK"])
-        self._download_2d(self.c_eff, OUT["subCeff"])
+        # subK / subCeff stay on the device: they are allocated in INIT but
+        # never read anywhere else in EBFM, and they are not part of
+        # --dump-reference, so copying them back is 2 full grids per timestep
+        # of pure waste. cpi is likewise a diagnostic nothing consumes.
         OUT["cpi"] = 152.2 + 7.122 * OUT["subT"]
 
 

--- a/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
+++ b/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
@@ -136,93 +136,93 @@ def _compaction_kernel_gpu(
 ):
     """GPU equivalent of _compaction_kernel. One CUDA thread per grid column."""
     i = cuda.grid(1)
-    if i >= subD.shape[0]:
+    if i >= subD.shape[1]:
         return
-    nl = subD.shape[1]
+    nl = subD.shape[0]
 
     # ------ 1. FIRN COMPACTION ------ #
     for k in range(nl):
-        subTmean[i, k] = subTmean[i, k] * (1.0 - dt_yearfrac) + dt_yearfrac * subT[i, k]
-        cond_firn_k = (compaction_mode == 0) or (subD[i, k] >= Dfirn)
+        subTmean[k, i] = subTmean[k, i] * (1.0 - dt_yearfrac) + dt_yearfrac * subT[k, i]
+        cond_firn_k = (compaction_mode == 0) or (subD[k, i] >= Dfirn)
         if cond_firn_k:
-            if subD[i, k] < 550.0:
-                grav_const = 0.07 * _fmax(1.435 - 0.151 * logyearsnow[i, k], 0.25)
+            if subD[k, i] < 550.0:
+                grav_const = 0.07 * _fmax(1.435 - 0.151 * logyearsnow[k, i], 0.25)
             else:
-                grav_const = 0.03 * _fmax(2.366 - 0.293 * logyearsnow[i, k], 0.25)
-            temp_factor = math.exp(-Ec / (rd * subT[i, k]) + Eg / (rd * subTmean[i, k]))
-            firn_inc = dt_yearfrac * grav_const * yearsnow[i, k] * g * (Dice - subD[i, k]) * temp_factor
-            subD[i, k] += firn_inc
+                grav_const = 0.03 * _fmax(2.366 - 0.293 * logyearsnow[k, i], 0.25)
+            temp_factor = math.exp(-Ec / (rd * subT[k, i]) + Eg / (rd * subTmean[k, i]))
+            firn_inc = dt_yearfrac * grav_const * yearsnow[k, i] * g * (Dice - subD[k, i]) * temp_factor
+            subD[k, i] += firn_inc
 
     # ------ 2. SEASONAL SNOW COMPACTION ------ #
     if compaction_mode == 1:  # firn+snow
         # Capture pre-DM snow mask
         for k in range(nl):
-            was_snow_ws[i, k] = subD[i, k] < Dfirn
+            was_snow_ws[k, i] = subD[k, i] < Dfirn
 
         # ------ 2.1 DESTRUCTIVE METAMORPHISM ------ #
         for k in range(nl):
-            if was_snow_ws[i, k]:
-                cc1 = math.exp(-0.046 * _fmax(subD[i, k] - 175.0, 0.0))
-                cc2 = 1.0 + (1.0 if subW[i, k] != 0.0 else 0.0)
-                temp_exp = math.exp(0.04 * (subT[i, k] - T0))
-                snow_inc = cc1 * cc2 * 2.777e-6 * temp_exp * dt_seconds * subD[i, k]
-                subD[i, k] = _fmin(subD[i, k] + snow_inc, Dice)
-                Dens_destr_metam[i, k] = snow_inc
+            if was_snow_ws[k, i]:
+                cc1 = math.exp(-0.046 * _fmax(subD[k, i] - 175.0, 0.0))
+                cc2 = 1.0 + (1.0 if subW[k, i] != 0.0 else 0.0)
+                temp_exp = math.exp(0.04 * (subT[k, i] - T0))
+                snow_inc = cc1 * cc2 * 2.777e-6 * temp_exp * dt_seconds * subD[k, i]
+                subD[k, i] = _fmin(subD[k, i] + snow_inc, Dice)
+                Dens_destr_metam[k, i] = snow_inc
             else:
-                Dens_destr_metam[i, k] = 0.0
+                Dens_destr_metam[k, i] = 0.0
 
         # ------ 2.2 OVERBURDEN PRESSURE ------ #
-        psload_ws[i, 0] = 0.5 * subD[i, 0] * subZ[i, 0] * g
+        psload_ws[0, i] = 0.5 * subD[0, i] * subZ[0, i] * g
         for k in range(1, nl):
-            xm = subD[i, k - 1] * subZ[i, k - 1] * g
-            xk = subD[i, k] * subZ[i, k] * g
-            psload_ws[i, k] = psload_ws[i, k - 1] + 0.5 * (xm + xk)
+            xm = subD[k - 1, i] * subZ[k - 1, i] * g
+            xk = subD[k, i] * subZ[k, i] * g
+            psload_ws[k, i] = psload_ws[k - 1, i] + 0.5 * (xm + xk)
 
         for k in range(nl):
-            Dens_overb_pres[i, k] = 0.0
-            if was_snow_ws[i, k]:
-                cc7 = 4.0 * 7.62237e6 / 250.0 * subD[i, k] / (1.0 + 60.0 * subW[i, k] / (Dwater * subZ[i, k]))
-                visc = cc7 * math.exp(0.1 * (T0 - subT[i, k]) + 0.023 * subD[i, k])
-                overb_inc = dt * dayseconds * subD[i, k] * psload_ws[i, k] / visc
-                subD[i, k] = _fmin(subD[i, k] + overb_inc, Dice)
-                Dens_overb_pres[i, k] = dt * dayseconds * subD[i, k] * psload_ws[i, k] / visc
+            Dens_overb_pres[k, i] = 0.0
+            if was_snow_ws[k, i]:
+                cc7 = 4.0 * 7.62237e6 / 250.0 * subD[k, i] / (1.0 + 60.0 * subW[k, i] / (Dwater * subZ[k, i]))
+                visc = cc7 * math.exp(0.1 * (T0 - subT[k, i]) + 0.023 * subD[k, i])
+                overb_inc = dt * dayseconds * subD[k, i] * psload_ws[k, i] / visc
+                subD[k, i] = _fmin(subD[k, i] + overb_inc, Dice)
+                Dens_overb_pres[k, i] = dt * dayseconds * subD[k, i] * psload_ws[k, i] / visc
 
         # ------ 2.3 DRIFTING SNOW ------ #
         z_i_k = 0.0
         for k in range(nl):
-            d_k = _fmax(subD[i, k], 50.0)
+            d_k = _fmax(subD[k, i], 50.0)
             mo_k = -0.069 + 0.66 * (1.25 - 0.0042 * (d_k - 50.0))
             si_k = -2.868 * math.exp(-0.085 * WS[i]) + 1.0 + mo_k
             gamma_k = _fmax(0.0, si_k * math.exp(-z_i_k / 0.1))
-            Dens_drift[i, k] = 0.0
-            if si_k > 0.0 and subD[i, k] < Dfirn:
+            Dens_drift[k, i] = 0.0
+            if si_k > 0.0 and subD[k, i] < Dfirn:
                 tau_i_k = tau_drift / gamma_k
-                drift_inc = dt_seconds * _fmax(350.0 - subD[i, k], 0.0) / tau_i_k
-                subD[i, k] = _fmin(subD[i, k] + drift_inc, Dice)
-                Dens_drift[i, k] = drift_inc
-            z_i_k += subZ[i, k] * (3.25 - si_k)
+                drift_inc = dt_seconds * _fmax(350.0 - subD[k, i], 0.0) / tau_i_k
+                subD[k, i] = _fmin(subD[k, i] + drift_inc, Dice)
+                Dens_drift[k, i] = drift_inc
+            z_i_k += subZ[k, i] * (3.25 - si_k)
 
     # ------ 3. UPDATE LAYER THICKNESS & SURFACE HEIGHT ------ #
     z_sum = 0.0
     z_sum_old = 0.0
     subW_sum = 0.0
     for k in range(nl):
-        # subZ is only read in sections 1-2, so subZ[i, k] still holds the
+        # subZ is only read in sections 1-2, so subZ[k, i] still holds the
         # pre-compaction thickness here. Take it before overwriting it below;
         # no separate subZ_old array is needed.
-        z_old_k = subZ[i, k]
-        if subD[i, k] < Dice:
-            subZ[i, k] = z_old_k * subD_old[i, k] / subD[i, k]
-            exp_f = 0.0143 * math.exp(3.3 * (Dice - subD[i, k]) / Dice)
+        z_old_k = subZ[k, i]
+        if subD[k, i] < Dice:
+            subZ[k, i] = z_old_k * subD_old[k, i] / subD[k, i]
+            exp_f = 0.0143 * math.exp(3.3 * (Dice - subD[k, i]) / Dice)
             denom = 1.0 - exp_f
-            mliqmax_k = subD[i, k] * subZ[i, k] * exp_f / denom * 0.05 * _fmin(Dice - subD[i, k], 20.0)
-            if subW[i, k] > mliqmax_k:
-                subW[i, k] = mliqmax_k
+            mliqmax_k = subD[k, i] * subZ[k, i] * exp_f / denom * 0.05 * _fmin(Dice - subD[k, i], 20.0)
+            if subW[k, i] > mliqmax_k:
+                subW[k, i] = mliqmax_k
         else:
-            subW[i, k] = 0.0
-        z_sum += subZ[i, k]
+            subW[k, i] = 0.0
+        z_sum += subZ[k, i]
         z_sum_old += z_old_k
-        subW_sum += subW[i, k]
+        subW_sum += subW[k, i]
 
     surfH[i] += z_sum - z_sum_old
     runoff_irr[i] = sumWinit[i] - subW_sum
@@ -248,13 +248,13 @@ def _heat_conduction_kernel_gpu(
 ):
     """GPU equivalent of _heat_conduction_kernel. One CUDA thread per grid column."""
     i = cuda.grid(1)
-    if i >= subT.shape[0]:
+    if i >= subT.shape[1]:
         return
-    nl = subT.shape[1]
+    nl = subT.shape[0]
 
     for k in range(nl):
-        T_loc_ws[i, k] = subT[i, k]
-        kdTdz_ws[i, k] = 0.0
+        T_loc_ws[k, i] = subT[k, i]
+        kdTdz_ws[k, i] = 0.0
 
     tt_i = 0.0
     while tt_i < dt:
@@ -265,18 +265,18 @@ def _heat_conduction_kernel_gpu(
         C_day_dt = dayseconds * dt_temp_i
 
         # Freeze fluxes from current T_loc
-        kdTdz_ws[i, 1] = kk_sz_top[i] * (T_loc_ws[i, 1] - Tsurf[i]) / dz1[i]
+        kdTdz_ws[1, i] = kk_sz_top[i] * (T_loc_ws[1, i] - Tsurf[i]) / dz1[i]
         for k in range(2, nl):
-            kdTdz_ws[i, k] = kk_sz_interior[i, k - 2] * (T_loc_ws[i, k] - T_loc_ws[i, k - 1]) / dz2[i, k - 2]
+            kdTdz_ws[k, i] = kk_sz_interior[k - 2, i] * (T_loc_ws[k, i] - T_loc_ws[k - 1, i]) / dz2[k - 2, i]
 
         # Update T_loc in-place
-        T_loc_ws[i, 1] += C_day_dt * (kdTdz_ws[i, 2] - kdTdz_ws[i, 1]) / denom_layer1[i]
+        T_loc_ws[1, i] += C_day_dt * (kdTdz_ws[2, i] - kdTdz_ws[1, i]) / denom_layer1[i]
         for k in range(2, nl - 1):
-            T_loc_ws[i, k] += C_day_dt * (kdTdz_ws[i, k + 1] - kdTdz_ws[i, k]) / denom_interior[i, k - 2]
-        T_loc_ws[i, nl - 1] += C_day_dt * (geothermal_flux - kdTdz_ws[i, nl - 1]) / denom_bottom[i]
+            T_loc_ws[k, i] += C_day_dt * (kdTdz_ws[k + 1, i] - kdTdz_ws[k, i]) / denom_interior[k - 2, i]
+        T_loc_ws[nl - 1, i] += C_day_dt * (geothermal_flux - kdTdz_ws[nl - 1, i]) / denom_bottom[i]
 
     for k in range(nl):
-        subT[i, k] = T_loc_ws[i, k]
+        subT[k, i] = T_loc_ws[k, i]
 
 
 @cuda.jit
@@ -310,9 +310,9 @@ def _percolation_kernel_gpu(
 ):
     """GPU equivalent of _percolation_kernel. One CUDA thread per grid column."""
     i = cuda.grid(1)
-    if i >= subT.shape[0]:
+    if i >= subT.shape[1]:
         return
-    nl = subT.shape[1]
+    nl = subT.shape[0]
 
     sigma2_2 = 2.0 * (perc_depth / 3.0) ** 2
     norm_coeff = 2.0 / (perc_depth / 3.0) / math.sqrt(2.0 * math.pi)
@@ -320,62 +320,62 @@ def _percolation_kernel_gpu(
 
     # ------ Refreezing and Irreducible Water Storage Limits ------ #
     for k in range(nl):
-        cpi_k = 152.2 + 7.122 * subT[i, k]
-        c1_k = cpi_k * subD[i, k] * subZ[i, k] * (T0 - subT[i, k]) / Lm
-        c2_k = subZ[i, k] * (1.0 - subD[i, k] / Dice) * Dice
-        wlim_ws[i, k] = _fmax(_fmin(c1_k, c2_k), 0.0)
-        if subD[i, k] < Dice - 1.0:
-            factor_k = 3.3 * (Dice - subD[i, k]) / Dice
+        cpi_k = 152.2 + 7.122 * subT[k, i]
+        c1_k = cpi_k * subD[k, i] * subZ[k, i] * (T0 - subT[k, i]) / Lm
+        c2_k = subZ[k, i] * (1.0 - subD[k, i] / Dice) * Dice
+        wlim_ws[k, i] = _fmax(_fmin(c1_k, c2_k), 0.0)
+        if subD[k, i] < Dice - 1.0:
+            factor_k = 3.3 * (Dice - subD[k, i]) / Dice
             exp_f = math.exp(factor_k)
             irr_f = 0.0143 * exp_f / (1.0 - 0.0143 * exp_f)
-            mliqmax_k = subD[i, k] * subZ[i, k] * irr_f * 0.05 * _fmin(Dice - subD[i, k], 20.0)
+            mliqmax_k = subD[k, i] * subZ[k, i] * irr_f * 0.05 * _fmin(Dice - subD[k, i], 20.0)
         else:
             mliqmax_k = 0.0
-        wirr_ws[i, k] = mliqmax_k - subW[i, k]
+        wirr_ws[k, i] = mliqmax_k - subW[k, i]
 
     # ------ Carrot (water-distribution profile) ------ #
     if percolation_mode == 0:
-        carrot_ws[i, 0] = 1.0
+        carrot_ws[0, i] = 1.0
         for k in range(1, nl):
-            carrot_ws[i, k] = 0.0
+            carrot_ws[k, i] = 0.0
     else:
         depth = 0.0
         for k in range(nl):
-            zz_k = depth + 0.5 * subZ[i, k]
+            zz_k = depth + 0.5 * subZ[k, i]
             if percolation_mode == 1:
-                carrot_ws[i, k] = norm_coeff * math.exp(-(zz_k * zz_k) / sigma2_2)
+                carrot_ws[k, i] = norm_coeff * math.exp(-(zz_k * zz_k) / sigma2_2)
             elif percolation_mode == 2:
                 v = 2.0 * (perc_depth - zz_k) / (perc_depth * perc_depth)
-                carrot_ws[i, k] = v if v > 0.0 else 0.0
-            depth += subZ[i, k]
+                carrot_ws[k, i] = v if v > 0.0 else 0.0
+            depth += subZ[k, i]
 
     s = 0.0
     for k in range(nl):
-        carrot_ws[i, k] *= subZ[i, k]
-        s += carrot_ws[i, k]
+        carrot_ws[k, i] *= subZ[k, i]
+        s += carrot_ws[k, i]
     avail_W_i = avail_W[i]
     for k in range(nl):
-        carrot_ws[i, k] = carrot_ws[i, k] / s * avail_W_i
+        carrot_ws[k, i] = carrot_ws[k, i] / s * avail_W_i
 
     # ------ Percolation: refreezing + irreducible storage ------ #
     avail_W_loc = 0.0
     rp_sum = 0.0
     for n in range(nl):
-        avail_W_loc += carrot_ws[i, n]
-        rp_n = _fmin(avail_W_loc, wlim_ws[i, n])
-        RP[i, n] = rp_n
-        excess = avail_W_loc - wlim_ws[i, n]
+        avail_W_loc += carrot_ws[n, i]
+        rp_n = _fmin(avail_W_loc, wlim_ws[n, i])
+        RP[n, i] = rp_n
+        excess = avail_W_loc - wlim_ws[n, i]
         if excess < 0.0:
             excess = 0.0
-        # subW[i, n] still holds the pre-percolation value at this point; read
+        # subW[n, i] still holds the pre-percolation value at this point; read
         # it before overwriting, so no separate subW_old array is needed.
-        w_old_n = subW[i, n]
-        new_subW_n = w_old_n + _fmin(excess, wirr_ws[i, n])
-        subW[i, n] = new_subW_n
+        w_old_n = subW[n, i]
+        new_subW_n = w_old_n + _fmin(excess, wirr_ws[n, i])
+        subW[n, i] = new_subW_n
         avail_W_loc -= rp_n + (new_subW_n - w_old_n)
-        cpi_n = 152.2 + 7.122 * subT[i, n]
-        subT[i, n] += Lm * rp_n / (subD[i, n] * cpi_n * subZ[i, n])
-        subD[i, n] += rp_n / subZ[i, n]
+        cpi_n = 152.2 + 7.122 * subT[n, i]
+        subT[n, i] += Lm * rp_n / (subD[n, i] * cpi_n * subZ[n, i])
+        subD[n, i] += rp_n / subZ[n, i]
         rp_sum += rp_n
 
     avail_W[i] = avail_W_loc
@@ -383,15 +383,15 @@ def _percolation_kernel_gpu(
     # ------ Slush water storage ------ #
     total_slushspace = 0.0
     for k in range(nl):
-        ss_k = subZ[i, k] * (1.0 - subD[i, k] / Dice) * Dwater - subW[i, k]
+        ss_k = subZ[k, i] * (1.0 - subD[k, i] / Dice) * Dwater - subW[k, i]
         if ss_k < 0.0:
             ss_k = 0.0
-        slushspace_ws[i, k] = ss_k
+        slushspace_ws[k, i] = ss_k
         total_slushspace += ss_k
 
     old_slush_sum = 0.0
     for k in range(nl):
-        old_slush_sum += subS[i, k]
+        old_slush_sum += subS[k, i]
     avail_W_slush = avail_W_loc + old_slush_sum
 
     surf_ro = avail_W_slush - total_slushspace
@@ -403,49 +403,49 @@ def _percolation_kernel_gpu(
         avail_S = 0.0
 
     for n in range(nl - 1, -1, -1):
-        fill = avail_S if avail_S < slushspace_ws[i, n] else slushspace_ws[i, n]
-        subS[i, n] = fill
+        fill = avail_S if avail_S < slushspace_ws[n, i] else slushspace_ws[n, i]
+        subS[n, i] = fill
         avail_S -= fill
 
     # ------ Slush refreezing ------ #
     rs_sum = 0.0
     for k in range(nl):
-        cpi_k = 152.2 + 7.122 * subT[i, k]
-        c1_k = cpi_k * subD[i, k] * subZ[i, k] * (T0 - subT[i, k]) / Lm
-        c2_k = subZ[i, k] * (1.0 - subD[i, k] / Dice) * Dice
+        cpi_k = 152.2 + 7.122 * subT[k, i]
+        c1_k = cpi_k * subD[k, i] * subZ[k, i] * (T0 - subT[k, i]) / Lm
+        c2_k = subZ[k, i] * (1.0 - subD[k, i] / Dice) * Dice
         wlim_k = _fmin(c1_k, c2_k)
         rs_k = 0.0
-        if subS[i, k] > 0.0 and subT[i, k] < T0:
-            rs_k = subS[i, k] if subS[i, k] < wlim_k else wlim_k
+        if subS[k, i] > 0.0 and subT[k, i] < T0:
+            rs_k = subS[k, i] if subS[k, i] < wlim_k else wlim_k
             if rs_k < 0.0:
                 rs_k = 0.0
-        subS[i, k] -= rs_k
-        subT[i, k] += (Lm * rs_k) / (subD[i, k] * cpi_k * subZ[i, k])
-        subD[i, k] += rs_k / subZ[i, k]
+        subS[k, i] -= rs_k
+        subT[k, i] += (Lm * rs_k) / (subD[k, i] * cpi_k * subZ[k, i])
+        subD[k, i] += rs_k / subZ[k, i]
         rs_sum += rs_k
 
     # ------ Irreducible water refreezing ------ #
     ri_sum = 0.0
     for k in range(nl):
-        cpi_k = 152.2 + 7.122 * subT[i, k]
-        c1_k = cpi_k * subD[i, k] * subZ[i, k] * (T0 - subT[i, k]) / Lm
-        c2_k = subZ[i, k] * (1.0 - subD[i, k] / Dice) * Dice
+        cpi_k = 152.2 + 7.122 * subT[k, i]
+        c1_k = cpi_k * subD[k, i] * subZ[k, i] * (T0 - subT[k, i]) / Lm
+        c2_k = subZ[k, i] * (1.0 - subD[k, i] / Dice) * Dice
         wlim_k = _fmin(c1_k, c2_k)
         ri_k = 0.0
-        if subW[i, k] > 0.0 and subT[i, k] < T0:
-            ri_k = subW[i, k] if subW[i, k] < wlim_k else wlim_k
+        if subW[k, i] > 0.0 and subT[k, i] < T0:
+            ri_k = subW[k, i] if subW[k, i] < wlim_k else wlim_k
             if ri_k < 0.0:
                 ri_k = 0.0
-        subW[i, k] -= ri_k
-        subT[i, k] += (Lm * ri_k) / (subD[i, k] * cpi_k * subZ[i, k])
-        subD[i, k] += ri_k / subZ[i, k]
+        subW[k, i] -= ri_k
+        subT[k, i] += (Lm * ri_k) / (subD[k, i] * cpi_k * subZ[k, i])
+        subD[k, i] += ri_k / subZ[k, i]
         ri_sum += ri_k
 
     slushw_i = 0.0
     irrw_i = 0.0
     for k in range(nl):
-        slushw_i += subS[i, k]
-        irrw_i += subW[i, k]
+        slushw_i += subS[k, i]
+        irrw_i += subW[k, i]
     refr_P[i] = 1e-3 * rp_sum
     refr_S[i] = 1e-3 * rs_sum
     refr_I[i] = 1e-3 * ri_sum
@@ -478,53 +478,53 @@ def _heat_conduction_prep_kernel_gpu(
     to the NumPy path in LOOP_SNOW.heat_conduction() for --dump-reference parity.
     """
     i = cuda.grid(1)
-    if i >= subD.shape[0]:
+    if i >= subD.shape[1]:
         return
-    nl = subD.shape[1]
+    nl = subD.shape[0]
 
     # Effective conductivity and volumetric heat capacity per layer.
     for k in range(nl):
-        d = subD[i, k]
-        kk[i, k] = 0.138 - 1.01e-3 * d + 3.233e-6 * d * d
-        c_eff[i, k] = d * (152.2 + 7.122 * subT[i, k])
+        d = subD[k, i]
+        kk[k, i] = 0.138 - 1.01e-3 * d + 3.233e-6 * d * d
+        c_eff[k, i] = d * (152.2 + 7.122 * subT[k, i])
 
     # dz1 = (subZ[0] + 0.5*subZ[1])**2
-    half1 = subZ[i, 0] + 0.5 * subZ[i, 1]
+    half1 = subZ[0, i] + 0.5 * subZ[1, i]
     dz1[i] = half1 * half1
 
     # dz2 = 0.5 * (subZ[k+2] + subZ[k+1])**2   (NumPy: 0.5*(a+b)**2, NOT (0.5*(a+b))**2)
     for k in range(nl - 2):
-        s = subZ[i, k + 2] + subZ[i, k + 1]
-        dz2[i, k] = 0.5 * s * s
+        s = subZ[k + 2, i] + subZ[k + 1, i]
+        dz2[k, i] = 0.5 * s * s
 
     # kk_sz_top = kk[0]*subZ[0] + 0.5*kk[1]*subZ[1]
-    kk_sz_top[i] = kk[i, 0] * subZ[i, 0] + 0.5 * kk[i, 1] * subZ[i, 1]
+    kk_sz_top[i] = kk[0, i] * subZ[0, i] + 0.5 * kk[1, i] * subZ[1, i]
 
     # kk_sz_interior[j] = kk[j+1]*subZ[j+1] + kk[j+2]*subZ[j+2]
     for k in range(nl - 2):
-        kk_sz_interior[i, k] = kk[i, k + 1] * subZ[i, k + 1] + kk[i, k + 2] * subZ[i, k + 2]
+        kk_sz_interior[k, i] = kk[k + 1, i] * subZ[k + 1, i] + kk[k + 2, i] * subZ[k + 2, i]
 
     # denom_layer1 = c_eff[1] * (0.5*subZ[0] + 0.5*subZ[1] + 0.25*subZ[2])
-    denom_layer1[i] = c_eff[i, 1] * (0.5 * subZ[i, 0] + 0.5 * subZ[i, 1] + 0.25 * subZ[i, 2])
+    denom_layer1[i] = c_eff[1, i] * (0.5 * subZ[0, i] + 0.5 * subZ[1, i] + 0.25 * subZ[2, i])
 
     # denom_interior[k-2] = c_eff[k] * (0.25*subZ[k-1] + 0.5*subZ[k] + 0.25*subZ[k+1]) for k in 2..nl-2
     for k in range(2, nl - 1):
-        denom_interior[i, k - 2] = c_eff[i, k] * (0.25 * subZ[i, k - 1] + 0.5 * subZ[i, k] + 0.25 * subZ[i, k + 1])
+        denom_interior[k - 2, i] = c_eff[k, i] * (0.25 * subZ[k - 1, i] + 0.5 * subZ[k, i] + 0.25 * subZ[k + 1, i])
 
     # denom_bottom = c_eff[-1] * (0.25*subZ[-2] + 0.75*subZ[-1])
-    denom_bottom[i] = c_eff[i, nl - 1] * (0.25 * subZ[i, nl - 2] + 0.75 * subZ[i, nl - 1])
+    denom_bottom[i] = c_eff[nl - 1, i] * (0.25 * subZ[nl - 2, i] + 0.75 * subZ[nl - 1, i])
 
     # dt_stab = 0.5 * min(c_eff[1:]) * min(subZ[1:])**2 / max(kk[1:]) / dayseconds
     min_ceff = math.inf
     min_sz = math.inf
     max_kk = 0.0
     for k in range(1, nl):
-        if c_eff[i, k] < min_ceff:
-            min_ceff = c_eff[i, k]
-        if subZ[i, k] < min_sz:
-            min_sz = subZ[i, k]
-        if kk[i, k] > max_kk:
-            max_kk = kk[i, k]
+        if c_eff[k, i] < min_ceff:
+            min_ceff = c_eff[k, i]
+        if subZ[k, i] < min_sz:
+            min_sz = subZ[k, i]
+        if kk[k, i] > max_kk:
+            max_kk = kk[k, i]
     dt_stab[i] = 0.5 * min_ceff * (min_sz * min_sz) / max_kk / dayseconds
 
 
@@ -537,14 +537,44 @@ def _heat_boundary_clip_kernel_gpu(subT, Tsurf, subZ, T0):
         np.clip(subT, None, T0, out=subT)
     """
     i = cuda.grid(1)
-    if i >= subT.shape[0]:
+    if i >= subT.shape[1]:
         return
-    nl = subT.shape[1]
+    nl = subT.shape[0]
 
-    subT[i, 0] = Tsurf[i] + (subT[i, 1] - Tsurf[i]) / (subZ[i, 0] + 0.5 * subZ[i, 1]) * 0.5 * subZ[i, 0]
+    subT[0, i] = Tsurf[i] + (subT[1, i] - Tsurf[i]) / (subZ[0, i] + 0.5 * subZ[1, i]) * 0.5 * subZ[0, i]
     for k in range(nl):
-        if subT[i, k] > T0:
-            subT[i, k] = T0
+        if subT[k, i] > T0:
+            subT[k, i] = T0
+
+
+@cuda.jit
+def _to_layer_major_kernel_gpu(src, dst):
+    """(gpsum, nl) -> (nl, gpsum). One thread per column."""
+    i = cuda.grid(1)
+    if i >= src.shape[0]:
+        return
+    for k in range(src.shape[1]):
+        dst[k, i] = src[i, k]
+
+
+@cuda.jit
+def _to_grid_major_kernel_gpu(src, dst):
+    """(nl, gpsum) -> (gpsum, nl). One thread per column."""
+    i = cuda.grid(1)
+    if i >= dst.shape[0]:
+        return
+    for k in range(dst.shape[1]):
+        dst[i, k] = src[k, i]
+
+
+@cuda.jit
+def _zero_kernel_gpu(arr):
+    """Zero a (nl, gpsum) array in place. One thread per column."""
+    i = cuda.grid(1)
+    if i >= arr.shape[1]:
+        return
+    for k in range(arr.shape[0]):
+        arr[k, i] = 0.0
 
 
 # ===========================================================================
@@ -588,31 +618,41 @@ class SnowDeviceState:
         self.shape = (gpsum, nl)
         self.blocks = _blocks(gpsum)
 
+        # Host-layout staging buffer. Transfers keep the host's (gpsum, nl)
+        # layout; a transpose kernel converts to/from the layer-major (nl,
+        # gpsum) layout the compute kernels use, so consecutive threads read
+        # consecutive addresses. Transposing on the device costs a single
+        # extra pass and avoids a per-step host-side transpose.
+        self._stage = cuda.device_array((gpsum, nl), dtype=np.float64)
+        # Percolation water input, refreshed each step (was re-allocated with
+        # cuda.to_device on every call).
+        self._avail_W = cuda.device_array((gpsum,), dtype=np.float64)
+
         # Resident state (read/write; refreshed in upload, read back in download).
-        self.subT = cuda.device_array((gpsum, nl), dtype=np.float64)
-        self.subD = cuda.device_array((gpsum, nl), dtype=np.float64)
-        self.subZ = cuda.device_array((gpsum, nl), dtype=np.float64)
-        self.subW = cuda.device_array((gpsum, nl), dtype=np.float64)
-        self.subS = cuda.device_array((gpsum, nl), dtype=np.float64)
-        self.subTmean = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self.subT = cuda.device_array((nl, gpsum), dtype=np.float64)
+        self.subD = cuda.device_array((nl, gpsum), dtype=np.float64)
+        self.subZ = cuda.device_array((nl, gpsum), dtype=np.float64)
+        self.subW = cuda.device_array((nl, gpsum), dtype=np.float64)
+        self.subS = cuda.device_array((nl, gpsum), dtype=np.float64)
+        self.subTmean = cuda.device_array((nl, gpsum), dtype=np.float64)
         self.surfH = cuda.device_array((gpsum,), dtype=np.float64)
 
         # Per-step inputs (read-only on the device).
-        self.logyearsnow = cuda.device_array((gpsum, nl), dtype=np.float64)
-        self.yearsnow = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self.logyearsnow = cuda.device_array((nl, gpsum), dtype=np.float64)
+        self.yearsnow = cuda.device_array((nl, gpsum), dtype=np.float64)
         self.WS = cuda.device_array((gpsum,), dtype=np.float64)
         self.Tsurf = cuda.device_array((gpsum,), dtype=np.float64)
         self.sumWinit = cuda.device_array((gpsum,), dtype=np.float64)
 
         # Dens_* diagnostics, refreshed from the host zeros each step.
-        self.Dens_destr_metam = cuda.device_array((gpsum, nl), dtype=np.float64)
-        self.Dens_overb_pres = cuda.device_array((gpsum, nl), dtype=np.float64)
-        self.Dens_drift = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self.Dens_destr_metam = cuda.device_array((nl, gpsum), dtype=np.float64)
+        self.Dens_overb_pres = cuda.device_array((nl, gpsum), dtype=np.float64)
+        self.Dens_drift = cuda.device_array((nl, gpsum), dtype=np.float64)
 
         # Conductivity / heat capacity filled by the heat-conduction prep kernel
         # and kept resident so download() returns subK/subCeff matching NumPy.
-        self.kk = cuda.device_array((gpsum, nl), dtype=np.float64)
-        self.c_eff = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self.kk = cuda.device_array((nl, gpsum), dtype=np.float64)
+        self.c_eff = cuda.device_array((nl, gpsum), dtype=np.float64)
 
         # Write-only column outputs (allocated, never uploaded).
         self.runoff_irr = cuda.device_array((gpsum,), dtype=np.float64)
@@ -625,24 +665,24 @@ class SnowDeviceState:
         self.irrw = cuda.device_array((gpsum,), dtype=np.float64)
 
         # Device-only scratch (never touches the host).
-        self._subD_old = cuda.device_array((gpsum, nl), dtype=np.float64)
-        self._was_snow_ws = cuda.device_array((gpsum, nl), dtype=np.bool_)
-        self._psload_ws = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self._subD_old = cuda.device_array((nl, gpsum), dtype=np.float64)
+        self._was_snow_ws = cuda.device_array((nl, gpsum), dtype=np.bool_)
+        self._psload_ws = cuda.device_array((nl, gpsum), dtype=np.float64)
         self._kk_sz_top = cuda.device_array((gpsum,), dtype=np.float64)
-        self._kk_sz_interior = cuda.device_array((gpsum, nl - 2), dtype=np.float64)
+        self._kk_sz_interior = cuda.device_array((nl - 2, gpsum), dtype=np.float64)
         self._dz1 = cuda.device_array((gpsum,), dtype=np.float64)
-        self._dz2 = cuda.device_array((gpsum, nl - 2), dtype=np.float64)
+        self._dz2 = cuda.device_array((nl - 2, gpsum), dtype=np.float64)
         self._denom_layer1 = cuda.device_array((gpsum,), dtype=np.float64)
-        self._denom_interior = cuda.device_array((gpsum, nl - 3), dtype=np.float64)
+        self._denom_interior = cuda.device_array((nl - 3, gpsum), dtype=np.float64)
         self._denom_bottom = cuda.device_array((gpsum,), dtype=np.float64)
         self._dt_stab = cuda.device_array((gpsum,), dtype=np.float64)
-        self._T_loc_ws = cuda.device_array((gpsum, nl), dtype=np.float64)
-        self._kdTdz_ws = cuda.device_array((gpsum, nl), dtype=np.float64)
-        self._RP = cuda.device_array((gpsum, nl), dtype=np.float64)
-        self._wlim_ws = cuda.device_array((gpsum, nl), dtype=np.float64)
-        self._wirr_ws = cuda.device_array((gpsum, nl), dtype=np.float64)
-        self._carrot_ws = cuda.device_array((gpsum, nl), dtype=np.float64)
-        self._slushspace_ws = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self._T_loc_ws = cuda.device_array((nl, gpsum), dtype=np.float64)
+        self._kdTdz_ws = cuda.device_array((nl, gpsum), dtype=np.float64)
+        self._RP = cuda.device_array((nl, gpsum), dtype=np.float64)
+        self._wlim_ws = cuda.device_array((nl, gpsum), dtype=np.float64)
+        self._wirr_ws = cuda.device_array((nl, gpsum), dtype=np.float64)
+        self._carrot_ws = cuda.device_array((nl, gpsum), dtype=np.float64)
+        self._slushspace_ws = cuda.device_array((nl, gpsum), dtype=np.float64)
 
     def upload(
         self,
@@ -660,24 +700,32 @@ class SnowDeviceState:
         sumWinit,
     ):
         """Refresh the device buffers with this timestep's host state."""
-        self.subT.copy_to_device(subT)
-        self.subD.copy_to_device(subD)
-        self.subZ.copy_to_device(subZ)
-        self.subW.copy_to_device(subW)
-        self.subS.copy_to_device(subS)
-        self.subTmean.copy_to_device(subTmean)
+        self._upload_2d(self.subT, subT)
+        self._upload_2d(self.subD, subD)
+        self._upload_2d(self.subZ, subZ)
+        self._upload_2d(self.subW, subW)
+        self._upload_2d(self.subS, subS)
+        self._upload_2d(self.subTmean, subTmean)
+        self._upload_2d(self.logyearsnow, logyearsnow)
+        self._upload_2d(self.yearsnow, yearsnow)
+        # 1-D per-column arrays need no transpose.
         self.surfH.copy_to_device(surfH)
-        self.logyearsnow.copy_to_device(logyearsnow)
-        self.yearsnow.copy_to_device(yearsnow)
         self.WS.copy_to_device(WS)
         self.Tsurf.copy_to_device(Tsurf)
         self.sumWinit.copy_to_device(sumWinit)
 
+    def _upload_2d(self, dst, host_arr):
+        """Host (gpsum, nl) -> device (nl, gpsum) via the staging buffer."""
+        self._stage.copy_to_device(host_arr)
+        _to_layer_major_kernel_gpu[self.blocks, _TPB](self._stage, dst)
+
+    def _download_2d(self, src, host_arr):
+        """Device (nl, gpsum) -> host (gpsum, nl) via the staging buffer."""
+        _to_grid_major_kernel_gpu[self.blocks, _TPB](src, self._stage)
+        self._stage.copy_to_host(host_arr)
+
     def compaction(
         self,
-        Dens_destr_metam,
-        Dens_overb_pres,
-        Dens_drift,
         dt_yearfrac,
         dt_seconds,
         dt,
@@ -686,10 +734,12 @@ class SnowDeviceState:
         mode,
     ):
         """Launch the compaction kernel on the resident arrays."""
-        # Upload host-zeroed diagnostics; firn_only leaves them untouched.
-        self.Dens_destr_metam.copy_to_device(Dens_destr_metam)
-        self.Dens_overb_pres.copy_to_device(Dens_overb_pres)
-        self.Dens_drift.copy_to_device(Dens_drift)
+        # The kernel only writes the Dens_* diagnostics in firn+snow mode, so
+        # they must start at zero. Zero them on the device rather than uploading
+        # host zeros (3 full grids per timestep of pure PCIe traffic).
+        _zero_kernel_gpu[self.blocks, _TPB](self.Dens_destr_metam)
+        _zero_kernel_gpu[self.blocks, _TPB](self.Dens_overb_pres)
+        _zero_kernel_gpu[self.blocks, _TPB](self.Dens_drift)
 
         # Snapshot pre-compaction subD/subZ on-device (host path does .copy()).
         self._subD_old.copy_to_device(self.subD)
@@ -772,7 +822,7 @@ class SnowDeviceState:
 
     def percolation(self, avail_W, C, perc_mode, dt):
         """Launch the percolation kernel on the resident arrays."""
-        d_avail_W = cuda.to_device(avail_W)
+        self._avail_W.copy_to_device(avail_W)
         # Snapshot post-heat subW on-device (host path does subW.copy()).
         _percolation_kernel_gpu[self.blocks, _TPB](
             self.subT,
@@ -780,7 +830,7 @@ class SnowDeviceState:
             self.subW,
             self.subS,
             self.subZ,
-            d_avail_W,
+            self._avail_W,
             self._RP,
             self.runoff_surface,
             self.runoff_slush,
@@ -806,16 +856,16 @@ class SnowDeviceState:
     def download(self, OUT):
         """Copy the resident state and every output back into OUT (once)."""
         # Resident state: written back in place, preserving array identity.
-        self.subT.copy_to_host(OUT["subT"])
-        self.subD.copy_to_host(OUT["subD"])
-        self.subZ.copy_to_host(OUT["subZ"])
-        self.subW.copy_to_host(OUT["subW"])
-        self.subS.copy_to_host(OUT["subS"])
-        self.subTmean.copy_to_host(OUT["subTmean"])
+        self._download_2d(self.subT, OUT["subT"])
+        self._download_2d(self.subD, OUT["subD"])
+        self._download_2d(self.subZ, OUT["subZ"])
+        self._download_2d(self.subW, OUT["subW"])
+        self._download_2d(self.subS, OUT["subS"])
+        self._download_2d(self.subTmean, OUT["subTmean"])
         self.surfH.copy_to_host(OUT["surfH"])
-        self.Dens_destr_metam.copy_to_host(OUT["Dens_destr_metam"])
-        self.Dens_overb_pres.copy_to_host(OUT["Dens_overb_pres"])
-        self.Dens_drift.copy_to_host(OUT["Dens_drift"])
+        self._download_2d(self.Dens_destr_metam, OUT["Dens_destr_metam"])
+        self._download_2d(self.Dens_overb_pres, OUT["Dens_overb_pres"])
+        self._download_2d(self.Dens_drift, OUT["Dens_drift"])
         self.runoff_irr.copy_to_host(OUT["runoff_irr"])
 
         # Percolation outputs. refr_* already carry the 1e-3 factor from the
@@ -834,8 +884,8 @@ class SnowDeviceState:
         # values. cpi is a diagnostic recomputed from the final subT; as in the
         # per-call GPU path this differs from NumPy only at the last refreezing
         # sub-step and is not consumed downstream.
-        self.kk.copy_to_host(OUT["subK"])
-        self.c_eff.copy_to_host(OUT["subCeff"])
+        self._download_2d(self.kk, OUT["subK"])
+        self._download_2d(self.c_eff, OUT["subCeff"])
         OUT["cpi"] = 152.2 + 7.122 * OUT["subT"]
 
 

--- a/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
+++ b/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
@@ -624,6 +624,10 @@ class SnowDeviceState:
         # consecutive addresses. Transposing on the device costs a single
         # extra pass and avoids a per-step host-side transpose.
         self._stage = cuda.device_array((gpsum, nl), dtype=np.float64)
+        # subTmean is read-modify-written only by compaction (device side); no
+        # host code touches it during the time loop. Upload it once and keep it
+        # resident, otherwise a stale host copy would overwrite the device one.
+        self._subTmean_uploaded = False
         # Percolation water input, refreshed each step (was re-allocated with
         # cuda.to_device on every call).
         self._avail_W = cuda.device_array((gpsum,), dtype=np.float64)
@@ -708,7 +712,9 @@ class SnowDeviceState:
         self._upload_2d(self.subZ, subZ)
         self._upload_2d(self.subW, subW)
         self._upload_2d(self.subS, subS)
-        self._upload_2d(self.subTmean, subTmean)
+        if not self._subTmean_uploaded:
+            self._upload_2d(self.subTmean, subTmean)
+            self._subTmean_uploaded = True
         # Layer-invariant: upload a single column instead of the tiled grid.
         self.logyearsnow.copy_to_device(np.ascontiguousarray(logyearsnow[:, 0]))
         self.yearsnow.copy_to_device(np.ascontiguousarray(yearsnow[:, 0]))
@@ -865,11 +871,7 @@ class SnowDeviceState:
         self._download_2d(self.subZ, OUT["subZ"])
         self._download_2d(self.subW, OUT["subW"])
         self._download_2d(self.subS, OUT["subS"])
-        self._download_2d(self.subTmean, OUT["subTmean"])
         self.surfH.copy_to_host(OUT["surfH"])
-        self._download_2d(self.Dens_destr_metam, OUT["Dens_destr_metam"])
-        self._download_2d(self.Dens_overb_pres, OUT["Dens_overb_pres"])
-        self._download_2d(self.Dens_drift, OUT["Dens_drift"])
         self.runoff_irr.copy_to_host(OUT["runoff_irr"])
 
         # Percolation outputs. refr_* already carry the 1e-3 factor from the
@@ -883,13 +885,23 @@ class SnowDeviceState:
         OUT["irrw"] = self.irrw.copy_to_host()
         OUT["refr"] = OUT["refr_P"] + OUT["refr_S"] + OUT["refr_I"]
 
-        # subK / subCeff are the post-compaction conductivity and heat capacity
-        # from the prep kernel, matching the values the NumPy path stores before
-        # the heat solve. Copied back so the GPU path leaves the same diagnostics
-        # in OUT as the NumPy and Numba paths.
+        OUT["cpi"] = 152.2 + 7.122 * OUT["subT"]
+
+    def download_diagnostics(self, OUT):
+        """Copy the device-resident diagnostics back into OUT.
+
+        subTmean, Dens_* and subK / subCeff are not read by any host code during
+        the time loop, so they stay on the device and are only flushed when the
+        values are actually needed: writing output, dumping a reference
+        snapshot, or creating a restart file. That removes six full grids per
+        timestep from the download path.
+        """
+        self._download_2d(self.subTmean, OUT["subTmean"])
+        self._download_2d(self.Dens_destr_metam, OUT["Dens_destr_metam"])
+        self._download_2d(self.Dens_overb_pres, OUT["Dens_overb_pres"])
+        self._download_2d(self.Dens_drift, OUT["Dens_drift"])
         self._download_2d(self.kk, OUT["subK"])
         self._download_2d(self.c_eff, OUT["subCeff"])
-        OUT["cpi"] = 152.2 + 7.122 * OUT["subT"]
 
 
 # ---------------------------------------------------------------------------
@@ -904,6 +916,12 @@ class SnowDeviceState:
 # ---------------------------------------------------------------------------
 
 _device_state = None
+
+
+def flush_device_diagnostics(OUT):
+    """Flush the device-resident diagnostics into OUT, if a GPU state exists."""
+    if _device_state is not None:
+        _device_state.download_diagnostics(OUT)
 
 
 def get_device_state(

--- a/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
+++ b/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
@@ -883,10 +883,12 @@ class SnowDeviceState:
         OUT["irrw"] = self.irrw.copy_to_host()
         OUT["refr"] = OUT["refr_P"] + OUT["refr_S"] + OUT["refr_I"]
 
-        # subK / subCeff stay on the device: they are allocated in INIT but
-        # never read anywhere else in EBFM, and they are not part of
-        # --dump-reference, so copying them back is 2 full grids per timestep
-        # of pure waste. cpi is likewise a diagnostic nothing consumes.
+        # subK / subCeff are the post-compaction conductivity and heat capacity
+        # from the prep kernel, matching the values the NumPy path stores before
+        # the heat solve. Copied back so the GPU path leaves the same diagnostics
+        # in OUT as the NumPy and Numba paths.
+        self._download_2d(self.kk, OUT["subK"])
+        self._download_2d(self.c_eff, OUT["subCeff"])
         OUT["cpi"] = 152.2 + 7.122 * OUT["subT"]
 
 

--- a/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
+++ b/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
@@ -8,8 +8,11 @@
 """
 GPU kernels for the LOOP_SNOW module.
 
-Availability: numba.cuda kernels for compaction, heat conduction and
-percolation, offloaded to a GPU when the GPU backend is active (--with-gpu).
+Availability: numba.cuda kernels for all six compute sub-steps of LOOP_SNOW --
+snowfall/deposition, melt/sublimation, compaction, heat conduction,
+percolation and layer merging/splitting -- offloaded to a GPU when the GPU
+backend is active (--with-gpu). Only runoff(), which is (gpsum,) vector
+arithmetic on values already downloaded, stays on the host.
 
 The same kernels run on both vendors:
 - NVIDIA via numba.cuda,
@@ -22,12 +25,11 @@ column. Per-column scratch arrays (suffix ``_ws``, shape ``(gpsum, nl)``) are
 pre-allocated on the device by ``SnowDeviceState`` to avoid dynamic allocation
 inside the kernels.
 
-``SnowDeviceState`` owns the device buffers for one LOOP_SNOW step: it uploads
-the subsurface state once, launches the compaction / heat-conduction /
-percolation kernels back-to-back while the shared arrays stay resident on the
-device, and copies every result back in one shot. The host-side physics glue
-lives in LOOP_SNOW.py (shared with the NumPy / Numba paths), so results match
-those paths exactly.
+``SnowDeviceState`` owns the device buffers: it uploads the subsurface state
+once per run, launches every sub-step kernel against the resident arrays, and
+copies back only what host code reads between timesteps. The host-side physics
+glue lives in LOOP_SNOW.py (shared with the NumPy / Numba paths), so results
+match those paths exactly.
 
 When no GPU stack is importable, ``cuda`` is a no-op stub (from
 compute_backend), so the @cuda.jit-decorated functions remain importable but
@@ -98,6 +100,355 @@ def _gpu_probe_kernel(arr):
     i = cuda.grid(1)
     if i < arr.shape[0]:
         arr[i] *= 2.0
+
+
+@cuda.jit
+def _snowfall_prep_kernel_gpu(
+    subZ,
+    Dfreshsnow,
+    Dfreshsnow_T,
+    Dfreshsnow_W,
+    shift_tot,
+    surfH,
+    runoff_irr_deep,
+    T,  # (gpsum,) air temperature
+    WS,  # (gpsum,) wind speed
+    snow,  # (gpsum,) snowfall
+    moist_deposition,  # (gpsum,) riming
+    Dwater,
+    T0,
+    Dfreshsnow_const,
+    compaction_mode,
+    more_flag,
+):
+    """Fresh-snow density + total grid shift. One CUDA thread per grid column.
+
+    Device equivalent of the block preceding the ``while np.any(shift_tot > 0)``
+    loop in snowfall_and_deposition(). ``more_flag`` receives the device-side
+    ``np.any(shift_tot > 0)`` that drives the host loop.
+    """
+    i = cuda.grid(1)
+    if i >= subZ.shape[1]:
+        return
+
+    if compaction_mode == 1:  # firn+snow: temperature/wind dependent fresh-snow density
+        t_i = T[i]
+        if t_i > T0 + 2.0:
+            d_t = 50.0 + 1.7 * 17.0**1.5
+        elif t_i > T0 - 15.0:
+            d_t = 50.0 + 1.7 * (t_i - T0 + 15.0) ** 1.5
+        else:
+            d_t = -3.8328 * (t_i - T0) - 0.0333 * (t_i - T0) ** 2
+        d_w = 266.86 * (0.5 * (1.0 + math.tanh(WS[i] / 5.0))) ** 8.8
+        Dfreshsnow_T[i] = d_t
+        Dfreshsnow_W[i] = d_w
+        Dfreshsnow[i] = d_t + d_w
+    else:
+        # The NumPy path leaves the two components undefined in firn_only mode;
+        # zero them rather than let download_state() hand back uninitialised
+        # device memory.
+        Dfreshsnow_T[i] = 0.0
+        Dfreshsnow_W[i] = 0.0
+        Dfreshsnow[i] = Dfreshsnow_const
+
+    d_fresh = Dfreshsnow[i]
+    shift_i = snow[i] * Dwater / d_fresh + moist_deposition[i] * Dwater / d_fresh
+    shift_tot[i] = shift_i
+    surfH[i] += shift_i
+    runoff_irr_deep[i] = 0.0
+
+    if shift_i > 0.0:
+        cuda.atomic.max(more_flag, 0, 1)
+
+
+@cuda.jit
+def _snowfall_shift_kernel_gpu(
+    subZ,
+    subT,
+    subD,
+    subW,
+    Dfreshsnow,
+    Tsurf,
+    shift_tot,
+    runoff_irr_deep,
+    max_subZ,
+    more_flag,
+):
+    """One pass of the snowfall grid-shift loop. One CUDA thread per column.
+
+    Device equivalent of the body of ``while np.any(shift_tot > 0)`` in
+    snowfall_and_deposition(). The host re-launches this kernel while
+    ``more_flag`` stays set, so every column executes exactly as many passes as
+    on the NumPy path (columns that are already finished see ``shift == 0`` and
+    run the same no-op arithmetic, which keeps the results bit-identical).
+    """
+    i = cuda.grid(1)
+    if i >= subZ.shape[1]:
+        return
+    nl = subZ.shape[0]
+
+    shift = _fmin(shift_tot[i], max_subZ)
+    shift_tot[i] -= shift
+
+    z0_old = subZ[0, i]
+    t0_old = subT[0, i]
+    d0_old = subD[0, i]
+
+    if z0_old + shift <= max_subZ:
+        # ------ no-shift branch: the new snow is absorbed by the top layer ------
+        z0_new = z0_old + shift
+        subZ[0, i] = z0_new
+        subT[0, i] = t0_old * z0_old / z0_new + Tsurf[i] * shift / z0_new
+        subD[0, i] = d0_old * z0_old / z0_new + Dfreshsnow[i] * shift / z0_new
+    else:
+        # ------ shift branch: push the whole column down by one layer ------
+        # The deepest layer is never written here, so its pre-shift water is
+        # still available for the deep-runoff bookkeeping below.
+        runoff_irr_deep[i] += subW[nl - 1, i]
+        w0_old = subW[0, i]
+
+        # subZ[2:nl-1] = subZ_old[1:nl-2]; writing high-to-low keeps the source
+        # values intact, so no column snapshot is needed.
+        for k in range(nl - 2, 1, -1):
+            subZ[k, i] = subZ[k - 1, i]
+            subT[k, i] = subT[k - 1, i]
+            subD[k, i] = subD[k - 1, i]
+            subW[k, i] = subW[k - 1, i]
+
+        z1_new = max_subZ
+        subZ[1, i] = z1_new
+        subZ[0, i] = (z0_old + shift) - max_subZ
+        subT[1, i] = t0_old * z0_old / z1_new + Tsurf[i] * (z1_new - z0_old) / z1_new
+        subT[0, i] = Tsurf[i]
+        subD[1, i] = d0_old * z0_old / z1_new + Dfreshsnow[i] * (z1_new - z0_old) / z1_new
+        subD[0, i] = Dfreshsnow[i]
+        subW[1, i] = w0_old
+        subW[0, i] = 0.0
+
+    if shift_tot[i] > 0.0:
+        cuda.atomic.max(more_flag, 0, 1)
+
+
+@cuda.jit
+def _melt_peel_kernel_gpu(subZ, subD, subW, melt, moist_sublimation, sumWinit, shift_tot, more_flag):
+    """Melt/sublimation mass removal. One CUDA thread per grid column.
+
+    Device equivalent of ``OUT["sumWinit"] = ...`` plus the
+    ``while np.any(mass_removed > 0)`` layer-peeling loop in melt_sublimation().
+    That loop is a no-op for columns whose mass is already used up (both of its
+    masks are False there), so it can be run per thread with a private trip
+    count instead of a host-driven one. ``more_flag`` receives the device-side
+    ``np.any(shift_tot < 0)`` for the shift loop that follows.
+    """
+    i = cuda.grid(1)
+    if i >= subZ.shape[1]:
+        return
+    nl = subZ.shape[0]
+
+    w_sum = 0.0
+    for k in range(nl):
+        w_sum += subW[k, i]
+    sumWinit[i] = w_sum
+
+    mass_removed = (melt[i] + moist_sublimation[i]) * 1e3
+    shift_i = 0.0
+    n = 0
+    # Bounded by nl: the NumPy path would raise IndexError past the column
+    # bottom, so stopping there cannot change any result it can produce.
+    while mass_removed > 0.0 and n < nl:
+        mass_layer = subD[n, i] * subZ[n, i]
+        if mass_removed > mass_layer:
+            # Layer fully removed
+            mass_removed -= subD[n, i] * subZ[n, i]
+            shift_i -= subZ[n, i]
+        else:
+            # Layer partially removed
+            shift_i -= (mass_removed / mass_layer) * subZ[n, i]
+            mass_removed = 0.0
+        n += 1
+
+    shift_tot[i] = shift_i
+    if shift_i < 0.0:
+        cuda.atomic.max(more_flag, 0, 1)
+
+
+@cuda.jit
+def _melt_shift_kernel_gpu(
+    subZ,
+    subT,
+    subD,
+    subW,
+    surfH,
+    shift_tot,
+    bottom_thickness,
+    more_flag,
+):
+    """One pass of the melt grid-shift loop. One CUDA thread per column.
+
+    Device equivalent of the body of ``while np.any(shift_tot < 0)`` in
+    melt_sublimation(); driven by the host the same way as
+    _snowfall_shift_kernel_gpu.
+    """
+    i = cuda.grid(1)
+    if i >= subZ.shape[1]:
+        return
+    nl = subZ.shape[0]
+
+    shift = _fmax(shift_tot[i], -subZ[1, i])
+    shift_tot[i] -= shift
+    surfH[i] += shift
+
+    z0_old = subZ[0, i]
+
+    if z0_old + shift > 1e-17:
+        # ------ no-shift branch: the top layer only gets thinner ------
+        z0_new = z0_old + shift
+        subZ[0, i] = z0_new
+        subW[0, i] = subW[0, i] * (z0_new / z0_old)
+    else:
+        # ------ shift branch: layers 0 and 1 collapse into one ------
+        z1_old = subZ[1, i]
+        t1_old = subT[1, i]
+        d1_old = subD[1, i]
+        w1_old = subW[1, i]
+
+        # subZ[1:nl-2] = subZ_old[2:nl-1]; writing low-to-high keeps the source
+        # values intact, so no column snapshot is needed.
+        for k in range(1, nl - 2):
+            subZ[k, i] = subZ[k + 1, i]
+            subT[k, i] = subT[k + 1, i]
+            subD[k, i] = subD[k + 1, i]
+            subW[k, i] = subW[k + 1, i]
+
+        z0_new = z0_old + z1_old + shift
+        subZ[0, i] = z0_new
+        subT[0, i] = t1_old
+        subD[0, i] = d1_old
+        subW[0, i] = w1_old * (z0_new / z1_old)
+
+        # The NumPy path re-assigns subT/subD of the deepest layer from its own
+        # (unshifted) value, i.e. a no-op; only the thickness and water reset.
+        subZ[nl - 1, i] = bottom_thickness
+        subW[nl - 1, i] = 0.0
+
+    if shift_tot[i] < 0.0:
+        cuda.atomic.max(more_flag, 0, 1)
+
+
+@cuda.jit
+def _layer_merging_splitting_kernel_gpu(
+    subZ,
+    subT,
+    subD,
+    subW,
+    subS,
+    runoff_irr_deep,
+    runoff_slush,
+    mask,  # (gpsum,) int — 1 marks an active (glacier) column
+    split_arr,  # (nsplit,) int — layer indices at which the thickness doubles
+    max_subZ,
+    top_thickness,  # (2**nsplit) * max_subZ
+):
+    """GPU equivalent of layer_merging_and_splitting(). One thread per column.
+
+    Ported from the current CPU code in LOOP_SNOW.py, not from the AMD
+    reference implementation: that one uses a linear extrapolation for the
+    deepest-layer temperature after a merge, whereas the CPU path carries the
+    previous deepest-layer temperature over unchanged, and it makes merge and
+    split mutually exclusive, whereas the CPU path evaluates the split
+    condition on the post-merge column so both can fire in the same pass.
+
+    Both branches shift the column in the direction that lets the source values
+    be read before they are overwritten (merge shifts up, so it runs
+    low-to-high; split shifts down, so it runs high-to-low), which removes the
+    five per-column snapshot arrays the host path allocates.
+    """
+    i = cuda.grid(1)
+    if i >= subZ.shape[1]:
+        return
+    if mask[i] != 1:
+        return
+    nl = subZ.shape[0]
+
+    # The host computes (2.0**n) * max_subZ; doubling gives bit-identical
+    # values (scaling a double by a power of two is exact) without a pow().
+    threshold = max_subZ
+    for n in range(split_arr.shape[0]):
+        split = split_arr[n]
+
+        # ------ Merge layers (accumulation case) ------
+        if subZ[split, i] <= threshold:
+            # The new base layer keeps the old deepest layer's T/D; read them
+            # before the shift below moves the column.
+            t_base = subT[nl - 1, i]
+            d_base = subD[nl - 1, i]
+            zm = subZ[split - 1, i]
+            zs = subZ[split, i]
+            den = zm + zs
+            subZ[split - 1, i] = den
+            subW[split - 1, i] = subW[split - 1, i] + subW[split, i]
+            subS[split - 1, i] = subS[split - 1, i] + subS[split, i]
+            subD[split - 1, i] = (zm * subD[split - 1, i] + zs * subD[split, i]) / den
+            subT[split - 1, i] = (zm * subT[split - 1, i] + zs * subT[split, i]) / den
+
+            # Shift the layers below the merge up by one
+            for k in range(split, nl - 1):
+                subZ[k, i] = subZ[k + 1, i]
+                subW[k, i] = subW[k + 1, i]
+                subS[k, i] = subS[k + 1, i]
+                subD[k, i] = subD[k + 1, i]
+                subT[k, i] = subT[k + 1, i]
+
+            # New layer at the base, inheriting the old deepest layer's T/D
+            subZ[nl - 1, i] = top_thickness
+            subT[nl - 1, i] = t_base
+            subD[nl - 1, i] = d_base
+            subW[nl - 1, i] = 0.0
+            subS[nl - 1, i] = 0.0
+
+        # ------ Split layers (ablation case), evaluated post-merge ------
+        if subZ[split - 2, i] > threshold:
+            # The layer pushed out of the bottom releases its water
+            runoff_irr_deep[i] += subW[nl - 1, i]
+            runoff_slush[i] += subS[nl - 1, i]
+
+            # Shift down by one first, so split-1 still holds its pre-split
+            # value when it is read as the shift source.
+            for k in range(nl - 1, split - 1, -1):
+                subZ[k, i] = subZ[k - 1, i]
+                subW[k, i] = subW[k - 1, i]
+                subS[k, i] = subS[k - 1, i]
+                subD[k, i] = subD[k - 1, i]
+                subT[k, i] = subT[k - 1, i]
+
+            # Halve the split layer and copy it into the freed slot below
+            subZ[split - 2, i] *= 0.5
+            subW[split - 2, i] *= 0.5
+            subS[split - 2, i] *= 0.5
+            subZ[split - 1, i] = subZ[split - 2, i]
+            subW[split - 1, i] = subW[split - 2, i]
+            subS[split - 1, i] = subS[split - 2, i]
+            subT[split - 1, i] = subT[split - 2, i]
+            subD[split - 1, i] = subD[split - 2, i]
+
+        threshold *= 2.0
+
+
+@cuda.jit
+def _all_ice_kernel_gpu(subD, Dice, all_ice):
+    """Column-wise ``np.all(subD >= Dice, axis=1)`` as a (gpsum,) uint8 flag.
+
+    LOOP_mass_balance is the only host code that reduces over the full density
+    grid between timesteps; computing the reduction here keeps subD resident.
+    """
+    i = cuda.grid(1)
+    if i >= subD.shape[1]:
+        return
+    for k in range(subD.shape[0]):
+        if subD[k, i] < Dice:
+            all_ice[i] = 0
+            return
+    all_ice[i] = 1
 
 
 @cuda.jit
@@ -578,40 +929,43 @@ def _zero_kernel_gpu(arr):
 
 
 # ===========================================================================
-# Device-resident state for one LOOP_SNOW step.
+# Device-resident subsurface state.
 #
 # SnowDeviceState keeps the subsurface arrays (subT/subD/subZ/subW/subS/
-# subTmean/surfH) on the GPU across the three snow sub-steps -- compaction,
-# heat conduction, percolation -- so they are uploaded once and downloaded
-# once per timestep instead of round-tripping per sub-step.
+# subTmean/surfH) on the GPU for the whole run. All six compute sub-steps of
+# LOOP_SNOW -- snowfall/deposition, melt/sublimation, compaction, heat
+# conduction, percolation, layer merging/splitting -- run against those
+# buffers, so the grids are uploaded once at the start and only come back when
+# host code actually needs them.
+#
+# Per timestep the transfers are:
+#   H2D  the (gpsum,) forcing vectors (T, WS, snow, Tsurf, melt, moisture
+#        fluxes, logyearsnow/yearsnow columns, percolation water input)
+#   D2H  the (gpsum,) result vectors plus five (gpsum,) layer slices that host
+#        code reads before the next LOOP_SNOW call -- see download_boundary()
+#
+# The full (gpsum, nl) grids move only on demand, via download_state(), for
+# netCDF samples, the restart file and --dump-reference.
 #
 # The host-side physics glue (mode selection, water-input formula, unit
 # conventions, output bookkeeping) stays in LOOP_SNOW.py, which is the single
 # source of truth shared with the NumPy and Numba paths. This class only owns
-# the device buffers and launches the five compute kernels above against them,
-# so --dump-reference parity with the NumPy/Numba paths is preserved.
-#
-# NOTE (lifetime): one instance currently lives for a single LOOP_SNOW step
-# (created after melt_sublimation, discarded after percolation), so the
-# transfer profile matches the previous fused core -- upload once, download
-# once per step. Hoisting the instance out of the time loop so the state
-# persists across timesteps -- syncing only subZ/subD/Tsurf at the LOOP_EBM /
-# LOOP_mass_balance boundary -- is the follow-up that turns the once-per-step
-# transfers into once-per-run.
+# the device buffers and launches the kernels above against them, so
+# --dump-reference parity with the NumPy/Numba paths is preserved.
 # ===========================================================================
 
 
 class SnowDeviceState:
     """GPU-resident subsurface state for LOOP_SNOW.
 
-    Allocates all device buffers once for a given grid shape. Each timestep
-    upload() refreshes the resident arrays and this step's inputs,
-    compaction() / heat_conduction() / percolation() launch their kernels
-    against those buffers, and download() copies every result back into the
-    OUT dict in one shot.
+    Allocates all device buffers once for a given grid shape. upload_state()
+    and upload_grid() run once per run; upload_forcing() refreshes this
+    timestep's (gpsum,) inputs; the six sub-step methods launch their kernels
+    against the resident buffers; download_boundary() returns the narrow slice
+    the host reads between timesteps and download_state() the full grids.
 
-    The instance is reused across timesteps (see get_device_state), so the
-    device allocations happen once per run instead of once per timestep.
+    The instance is reused across timesteps (see get_device_state), so both the
+    device allocations and the state upload happen once per run.
     """
 
     def __init__(self, gpsum, nl):
@@ -624,15 +978,28 @@ class SnowDeviceState:
         # consecutive addresses. Transposing on the device costs a single
         # extra pass and avoids a per-step host-side transpose.
         self._stage = cuda.device_array((gpsum, nl), dtype=np.float64)
-        # subTmean is read-modify-written only by compaction (device side); no
-        # host code touches it during the time loop. Upload it once and keep it
-        # resident, otherwise a stale host copy would overwrite the device one.
-        self._subTmean_uploaded = False
+        # Staging buffer for single-layer downloads. In the layer-major layout
+        # one layer is a contiguous (gpsum,) row, so the host boundary slices
+        # come back without a transpose.
+        self._stage_col = np.empty(gpsum, dtype=np.float64)
+        # The subsurface state is uploaded once per run and then stays on the
+        # device across timesteps; see upload_state().
+        self._state_uploaded = False
+        self._grid_uploaded = False
         # Percolation water input, refreshed each step (was re-allocated with
         # cuda.to_device on every call).
         self._avail_W = cuda.device_array((gpsum,), dtype=np.float64)
 
-        # Resident state (read/write; refreshed in upload, read back in download).
+        # Single-int32 device flag used to reproduce the host `np.any(...)`
+        # conditions of the two grid-shift loops without downloading the
+        # per-column shift arrays. See snowfall_and_deposition() /
+        # melt_sublimation().
+        self._flag = cuda.device_array((1,), dtype=np.int32)
+        self._flag_host = np.zeros(1, dtype=np.int32)
+
+        # Resident state: uploaded once per run (upload_state), read/written by
+        # every sub-step kernel, copied back only via download_boundary() /
+        # download_state().
         self.subT = cuda.device_array((nl, gpsum), dtype=np.float64)
         self.subD = cuda.device_array((nl, gpsum), dtype=np.float64)
         self.subZ = cuda.device_array((nl, gpsum), dtype=np.float64)
@@ -641,7 +1008,7 @@ class SnowDeviceState:
         self.subTmean = cuda.device_array((nl, gpsum), dtype=np.float64)
         self.surfH = cuda.device_array((gpsum,), dtype=np.float64)
 
-        # Per-step inputs (read-only on the device).
+        # Per-step forcing (read-only on the device; see upload_forcing).
         # logyearsnow / yearsnow are np.tile(x[:, None], (1, nl)) on the host,
         # i.e. identical for every layer. Keep only the (gpsum,) vector on the
         # device: 3 MB per step instead of 149 MB.
@@ -649,15 +1016,35 @@ class SnowDeviceState:
         self.yearsnow = cuda.device_array((gpsum,), dtype=np.float64)
         self.WS = cuda.device_array((gpsum,), dtype=np.float64)
         self.Tsurf = cuda.device_array((gpsum,), dtype=np.float64)
-        self.sumWinit = cuda.device_array((gpsum,), dtype=np.float64)
+        self.T = cuda.device_array((gpsum,), dtype=np.float64)
+        self.snow = cuda.device_array((gpsum,), dtype=np.float64)
+        self.melt = cuda.device_array((gpsum,), dtype=np.float64)
+        self.moist_deposition = cuda.device_array((gpsum,), dtype=np.float64)
+        self.moist_sublimation = cuda.device_array((gpsum,), dtype=np.float64)
 
-        # Dens_* diagnostics, refreshed from the host zeros each step.
+        # Grid geometry for layer merging/splitting; uploaded once (see
+        # upload_grid).
+        self.mask = cuda.device_array((gpsum,), dtype=np.int32)
+        self.split = None
+
+        # Produced on the device, consumed on the device.
+        self.sumWinit = cuda.device_array((gpsum,), dtype=np.float64)
+        self.shift_tot = cuda.device_array((gpsum,), dtype=np.float64)
+        self.Dfreshsnow = cuda.device_array((gpsum,), dtype=np.float64)
+        self.Dfreshsnow_T = cuda.device_array((gpsum,), dtype=np.float64)
+        self.Dfreshsnow_W = cuda.device_array((gpsum,), dtype=np.float64)
+        self.runoff_irr_deep = cuda.device_array((gpsum,), dtype=np.float64)
+        # np.all(subD >= Dice, axis=1) for LOOP_mass_balance, so the host never
+        # has to reduce over the resident density grid.
+        self.all_ice = cuda.device_array((gpsum,), dtype=np.uint8)
+
+        # Dens_* diagnostics, zeroed on the device at the start of compaction.
         self.Dens_destr_metam = cuda.device_array((nl, gpsum), dtype=np.float64)
         self.Dens_overb_pres = cuda.device_array((nl, gpsum), dtype=np.float64)
         self.Dens_drift = cuda.device_array((nl, gpsum), dtype=np.float64)
 
         # Conductivity / heat capacity filled by the heat-conduction prep kernel
-        # and kept resident so download() returns subK/subCeff matching NumPy.
+        # and kept resident so download_state() returns subK/subCeff matching NumPy.
         self.kk = cuda.device_array((nl, gpsum), dtype=np.float64)
         self.c_eff = cuda.device_array((nl, gpsum), dtype=np.float64)
 
@@ -691,38 +1078,47 @@ class SnowDeviceState:
         self._carrot_ws = cuda.device_array((nl, gpsum), dtype=np.float64)
         self._slushspace_ws = cuda.device_array((nl, gpsum), dtype=np.float64)
 
-    def upload(
-        self,
-        subT,
-        subD,
-        subZ,
-        subW,
-        subS,
-        subTmean,
-        surfH,
-        logyearsnow,
-        yearsnow,
-        WS,
-        Tsurf,
-        sumWinit,
-    ):
-        """Refresh the device buffers with this timestep's host state."""
-        self._upload_2d(self.subT, subT)
-        self._upload_2d(self.subD, subD)
-        self._upload_2d(self.subZ, subZ)
-        self._upload_2d(self.subW, subW)
-        self._upload_2d(self.subS, subS)
-        if not self._subTmean_uploaded:
-            self._upload_2d(self.subTmean, subTmean)
-            self._subTmean_uploaded = True
-        # Layer-invariant: upload a single column instead of the tiled grid.
-        self.logyearsnow.copy_to_device(np.ascontiguousarray(logyearsnow[:, 0]))
-        self.yearsnow.copy_to_device(np.ascontiguousarray(yearsnow[:, 0]))
-        # 1-D per-column arrays need no transpose.
-        self.surfH.copy_to_device(surfH)
-        self.WS.copy_to_device(WS)
-        self.Tsurf.copy_to_device(Tsurf)
-        self.sumWinit.copy_to_device(sumWinit)
+    def upload_state(self, OUT):
+        """Upload the subsurface state -- once per run, not once per timestep.
+
+        subT/subD/subZ/subW/subS/subTmean/surfH are written only by LOOP_SNOW,
+        which now runs entirely on the device, so after this initial upload the
+        device copy is the authoritative one for the rest of the run. Uploading
+        again would overwrite it with whatever stale values the host arrays
+        happen to hold.
+        """
+        if self._state_uploaded:
+            return
+        self._upload_2d(self.subT, OUT["subT"])
+        self._upload_2d(self.subD, OUT["subD"])
+        self._upload_2d(self.subZ, OUT["subZ"])
+        self._upload_2d(self.subW, OUT["subW"])
+        self._upload_2d(self.subS, OUT["subS"])
+        self._upload_2d(self.subTmean, OUT["subTmean"])
+        self.surfH.copy_to_device(OUT["surfH"])
+        self._state_uploaded = True
+
+    def upload_grid(self, grid):
+        """Upload the layer-merging geometry -- once per run; it never changes."""
+        if self._grid_uploaded:
+            return
+        self.mask.copy_to_device(np.ascontiguousarray(grid["mask"], dtype=np.int32))
+        self.split = cuda.to_device(np.ascontiguousarray(grid["split"], dtype=np.int32))
+        self._grid_uploaded = True
+
+    def upload_forcing(self, OUT, IN):
+        """Upload this timestep's forcing. All (gpsum,) vectors, no grids."""
+        # logyearsnow / yearsnow are np.tile(x[:, None], (1, nl)) on the host,
+        # i.e. layer-invariant; upload the column, not the grid.
+        self.logyearsnow.copy_to_device(np.ascontiguousarray(IN["logyearsnow"][:, 0]))
+        self.yearsnow.copy_to_device(np.ascontiguousarray(IN["yearsnow"][:, 0]))
+        self.T.copy_to_device(np.ascontiguousarray(IN["T"]))
+        self.WS.copy_to_device(np.ascontiguousarray(IN["WS"]))
+        self.snow.copy_to_device(np.ascontiguousarray(IN["snow"]))
+        self.Tsurf.copy_to_device(np.ascontiguousarray(OUT["Tsurf"]))
+        self.melt.copy_to_device(np.ascontiguousarray(OUT["melt"]))
+        self.moist_deposition.copy_to_device(np.ascontiguousarray(OUT["moist_deposition"]))
+        self.moist_sublimation.copy_to_device(np.ascontiguousarray(OUT["moist_sublimation"]))
 
     def _upload_2d(self, dst, host_arr):
         """Host (gpsum, nl) -> device (nl, gpsum) via the staging buffer."""
@@ -733,6 +1129,109 @@ class SnowDeviceState:
         """Device (nl, gpsum) -> host (gpsum, nl) via the staging buffer."""
         _to_grid_major_kernel_gpu[self.blocks, _TPB](src, self._stage)
         self._stage.copy_to_host(host_arr)
+
+    def _reset_flag(self):
+        """Clear the device 'more work to do' flag before a shift-loop pass."""
+        self._flag_host[0] = 0
+        self._flag.copy_to_device(self._flag_host)
+
+    def _flag_is_set(self) -> bool:
+        """Read back the device flag, i.e. the host's `np.any(...)` condition."""
+        self._flag.copy_to_host(self._flag_host)
+        return bool(self._flag_host[0])
+
+    def snowfall_and_deposition(self, C, grid, mode):
+        """Launch the snowfall / deposition kernels on the resident arrays.
+
+        The host `while np.any(shift_tot > 0)` loop becomes a host-driven
+        kernel relaunch: the kernels raise a single int32 device flag, which is
+        the only thing copied back per pass (4 bytes). Driving the loop from
+        the host rather than per thread matters for bit-exactness -- the NumPy
+        path applies the loop body to *every* column on every pass, including
+        the ones that are already finished, and that body is not an exact no-op
+        in floating point.
+        """
+        self._reset_flag()
+        _snowfall_prep_kernel_gpu[self.blocks, _TPB](
+            self.subZ,
+            self.Dfreshsnow,
+            self.Dfreshsnow_T,
+            self.Dfreshsnow_W,
+            self.shift_tot,
+            self.surfH,
+            self.runoff_irr_deep,
+            self.T,
+            self.WS,
+            self.snow,
+            self.moist_deposition,
+            C["Dwater"],
+            C["T0"],
+            C["Dfreshsnow"],
+            mode,
+            self._flag,
+        )
+        while self._flag_is_set():
+            self._reset_flag()
+            _snowfall_shift_kernel_gpu[self.blocks, _TPB](
+                self.subZ,
+                self.subT,
+                self.subD,
+                self.subW,
+                self.Dfreshsnow,
+                self.Tsurf,
+                self.shift_tot,
+                self.runoff_irr_deep,
+                grid["max_subZ"],
+                self._flag,
+            )
+
+    def melt_sublimation(self, bottom_thickness):
+        """Launch the melt / sublimation kernels on the resident arrays.
+
+        Same host-driven pattern as snowfall_and_deposition() for the grid
+        shift. The preceding layer-peeling loop is genuinely a no-op for
+        finished columns (both of its NumPy masks are False there), so it runs
+        per thread with a private trip count and needs no flag round-trip.
+        """
+        self._reset_flag()
+        _melt_peel_kernel_gpu[self.blocks, _TPB](
+            self.subZ,
+            self.subD,
+            self.subW,
+            self.melt,
+            self.moist_sublimation,
+            self.sumWinit,
+            self.shift_tot,
+            self._flag,
+        )
+        while self._flag_is_set():
+            self._reset_flag()
+            _melt_shift_kernel_gpu[self.blocks, _TPB](
+                self.subZ,
+                self.subT,
+                self.subD,
+                self.subW,
+                self.surfH,
+                self.shift_tot,
+                bottom_thickness,
+                self._flag,
+            )
+
+    def layer_merging_and_splitting(self, max_subZ, top_thickness):
+        """Launch the layer merging / splitting kernel on the resident arrays."""
+        _layer_merging_splitting_kernel_gpu[self.blocks, _TPB](
+            self.subZ,
+            self.subT,
+            self.subD,
+            self.subW,
+            self.subS,
+            self.runoff_irr_deep,
+            self.runoff_slush,
+            self.mask,
+            self.split,
+            max_subZ,
+            top_thickness,
+        )
 
     def compaction(
         self,
@@ -863,16 +1362,54 @@ class SnowDeviceState:
             self._slushspace_ws,
         )
 
-    def download(self, OUT):
-        """Copy the resident state and every output back into OUT (once)."""
-        # Resident state: written back in place, preserving array identity.
-        self._download_2d(self.subT, OUT["subT"])
-        self._download_2d(self.subD, OUT["subD"])
-        self._download_2d(self.subZ, OUT["subZ"])
-        self._download_2d(self.subW, OUT["subW"])
-        self._download_2d(self.subS, OUT["subS"])
+    def _download_layer(self, src, k, host_grid, col):
+        """Copy device layer ``k`` into column ``col`` of a host (gpsum, nl) grid.
+
+        In the layer-major device layout a layer is one contiguous (gpsum,)
+        row, so this is a single coalesced copy with no transpose.
+        """
+        src[k].copy_to_host(self._stage_col)
+        host_grid[:, col] = self._stage_col
+
+    def download_boundary(self, OUT, Dice):
+        """Copy back only what host code reads before the next LOOP_SNOW call.
+
+        With every LOOP_SNOW sub-step on the device, the subsurface grids no
+        longer have to round-trip per timestep. Between two LOOP_SNOW calls the
+        host reads exactly:
+
+            LOOP_EBM          subD[:, :2], subZ[:, :2] (GHF coefficients)
+            LOOP_EBM_GHF      subT[:, 1]
+            LOOP_EBM_SWout    subD[:, 0]
+            LOOP_mass_balance np.all(subD >= Dice, axis=1)   -> computed here
+            LOOP_SNOW.main    subT[:, -1] (T_ice)
+            runoff()          the (gpsum,) runoff / refreezing vectors
+
+        so only those come back: five (gpsum,) layer slices plus the per-column
+        vectors, instead of five full (gpsum, nl) grids.
+
+        IMPORTANT: this leaves OUT["subT"], OUT["subD"], OUT["subZ"],
+        OUT["subW"] and OUT["subS"] only *partially* refreshed -- the layers
+        listed above are current, the rest are stale. Any host code that reads
+        a full subsurface grid must call LOOP_SNOW.sync_gpu_state(OUT) first.
+        """
+        _all_ice_kernel_gpu[self.blocks, _TPB](self.subD, Dice, self.all_ice)
+
+        nl = self.shape[1]
+        self._download_layer(self.subD, 0, OUT["subD"], 0)
+        self._download_layer(self.subD, 1, OUT["subD"], 1)
+        self._download_layer(self.subZ, 0, OUT["subZ"], 0)
+        self._download_layer(self.subZ, 1, OUT["subZ"], 1)
+        self._download_layer(self.subT, 1, OUT["subT"], 1)
+
+        # T_ice is the deepest layer; hand it over directly rather than through
+        # the (otherwise stale) OUT["subT"] grid.
+        self.subT[nl - 1].copy_to_host(self._stage_col)
+        OUT["T_ice"] = self._stage_col.copy()
+
         self.surfH.copy_to_host(OUT["surfH"])
         self.runoff_irr.copy_to_host(OUT["runoff_irr"])
+        OUT["runoff_irr_deep"] = self.runoff_irr_deep.copy_to_host()
 
         # Percolation outputs. refr_* already carry the 1e-3 factor from the
         # kernel; runoff_* stay in mm and are scaled later in runoff().
@@ -885,23 +1422,42 @@ class SnowDeviceState:
         OUT["irrw"] = self.irrw.copy_to_host()
         OUT["refr"] = OUT["refr_P"] + OUT["refr_S"] + OUT["refr_I"]
 
-        OUT["cpi"] = 152.2 + 7.122 * OUT["subT"]
+        # Consumed by LOOP_mass_balance in place of its own full-grid reduction.
+        OUT["all_ice_column"] = self.all_ice.copy_to_host().astype(bool)
 
-    def download_diagnostics(self, OUT):
-        """Copy the device-resident diagnostics back into OUT.
+    def download_state(self, OUT):
+        """Copy the full device-resident state and diagnostics back into OUT.
 
-        subTmean, Dens_* and subK / subCeff are not read by any host code during
-        the time loop, so they stay on the device and are only flushed when the
-        values are actually needed: writing output, dumping a reference
-        snapshot, or creating a restart file. That removes six full grids per
-        timestep from the download path.
+        Called only when host code actually needs the complete grids: writing a
+        netCDF sample, a restart file, or a --dump-reference snapshot. Every
+        array here is either write-only during the time loop (the Dens_*
+        diagnostics, subK / subCeff, subTmean) or covered layer-wise by
+        download_boundary(), so nothing between timesteps depends on it.
         """
-        self._download_2d(self.subTmean, OUT["subTmean"])
-        self._download_2d(self.Dens_destr_metam, OUT["Dens_destr_metam"])
-        self._download_2d(self.Dens_overb_pres, OUT["Dens_overb_pres"])
-        self._download_2d(self.Dens_drift, OUT["Dens_drift"])
-        self._download_2d(self.kk, OUT["subK"])
-        self._download_2d(self.c_eff, OUT["subCeff"])
+        for src, key in (
+            (self.subT, "subT"),
+            (self.subD, "subD"),
+            (self.subZ, "subZ"),
+            (self.subW, "subW"),
+            (self.subS, "subS"),
+            (self.subTmean, "subTmean"),
+            (self.Dens_destr_metam, "Dens_destr_metam"),
+            (self.Dens_overb_pres, "Dens_overb_pres"),
+            (self.Dens_drift, "Dens_drift"),
+            (self.kk, "subK"),
+            (self.c_eff, "subCeff"),
+        ):
+            host = OUT.get(key)
+            if host is None or host.shape != self.shape:
+                host = np.empty(self.shape, dtype=np.float64)
+                OUT[key] = host
+            self._download_2d(src, host)
+
+        self.sumWinit.copy_to_host(OUT["sumWinit"])
+        OUT["Dfreshsnow"] = self.Dfreshsnow.copy_to_host()
+        OUT["Dfreshsnow_T"] = self.Dfreshsnow_T.copy_to_host()
+        OUT["Dfreshsnow_W"] = self.Dfreshsnow_W.copy_to_host()
+        OUT["cpi"] = 152.2 + 7.122 * OUT["subT"]
 
 
 # ---------------------------------------------------------------------------
@@ -918,49 +1474,27 @@ class SnowDeviceState:
 _device_state = None
 
 
-def flush_device_diagnostics(OUT):
-    """Flush the device-resident diagnostics into OUT, if a GPU state exists."""
+def sync_device_state(OUT):
+    """Copy the full device-resident state into OUT, if a GPU state exists."""
     if _device_state is not None:
-        _device_state.download_diagnostics(OUT)
+        _device_state.download_state(OUT)
 
 
-def get_device_state(
-    subT,
-    subD,
-    subZ,
-    subW,
-    subS,
-    subTmean,
-    surfH,
-    logyearsnow,
-    yearsnow,
-    WS,
-    Tsurf,
-    sumWinit,
-):
-    """Return the cached SnowDeviceState, refreshed with the current host state.
+def get_device_state(OUT, IN, grid):
+    """Return the cached SnowDeviceState, ready for this timestep.
 
-    Allocates on the first call (or if the grid shape changed) and uploads this
-    timestep's arrays into the existing device buffers on every call.
+    Allocates the device buffers and uploads the subsurface state on the first
+    call (or if the grid shape changed); afterwards only this timestep's
+    (gpsum,) forcing vectors are uploaded, because the subsurface state stays
+    resident across timesteps.
     """
     global _device_state
-    if _device_state is None or _device_state.shape != subD.shape:
-        gpsum, nl = subD.shape
+    if _device_state is None or _device_state.shape != OUT["subD"].shape:
+        gpsum, nl = OUT["subD"].shape
         _device_state = SnowDeviceState(gpsum, nl)
-    _device_state.upload(
-        subT,
-        subD,
-        subZ,
-        subW,
-        subS,
-        subTmean,
-        surfH,
-        logyearsnow,
-        yearsnow,
-        WS,
-        Tsurf,
-        sumWinit,
-    )
+    _device_state.upload_state(OUT)
+    _device_state.upload_grid(grid)
+    _device_state.upload_forcing(OUT, IN)
     return _device_state
 
 

--- a/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
+++ b/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
@@ -35,6 +35,7 @@ are never launched.
 """
 
 import math
+import os
 import warnings
 
 import numpy as np
@@ -42,7 +43,11 @@ import numpy as np
 from .compute_backend import cuda
 
 # Threads per block used for all 1-D column-parallel launches.
-_TPB = 128
+#
+# The best value is device- and kernel-dependent (these kernels are large, so
+# register pressure can limit occupancy). Override for experiments with
+# EBFM_GPU_TPB, e.g. EBFM_GPU_TPB=256.
+_TPB = int(os.environ.get("EBFM_GPU_TPB", "128"))
 
 
 def _blocks(gpsum: int) -> int:
@@ -567,47 +572,42 @@ def _heat_boundary_clip_kernel_gpu(subT, Tsurf, subZ, T0):
 
 
 class SnowDeviceState:
-    """GPU-resident subsurface state for one LOOP_SNOW step.
+    """GPU-resident subsurface state for LOOP_SNOW.
 
-    Uploads the resident arrays and this step's inputs on construction, exposes
-    compaction() / heat_conduction() / percolation() that launch their kernels
-    against the resident device arrays, and download() to copy every result
-    back into the OUT dict in one shot.
+    Allocates all device buffers once for a given grid shape. Each timestep
+    upload() refreshes the resident arrays and this step's inputs,
+    compaction() / heat_conduction() / percolation() launch their kernels
+    against those buffers, and download() copies every result back into the
+    OUT dict in one shot.
+
+    The instance is reused across timesteps (see get_device_state), so the
+    device allocations happen once per run instead of once per timestep.
     """
 
-    def __init__(
-        self,
-        subT,
-        subD,
-        subZ,
-        subW,
-        subS,
-        subTmean,
-        surfH,
-        logyearsnow,
-        yearsnow,
-        WS,
-        Tsurf,
-        sumWinit,
-    ):
-        gpsum, nl = subD.shape
+    def __init__(self, gpsum, nl):
+        self.shape = (gpsum, nl)
         self.blocks = _blocks(gpsum)
 
-        # Resident state (read/write; copied back in download()).
-        self.subT = cuda.to_device(subT)
-        self.subD = cuda.to_device(subD)
-        self.subZ = cuda.to_device(subZ)
-        self.subW = cuda.to_device(subW)
-        self.subS = cuda.to_device(subS)
-        self.subTmean = cuda.to_device(subTmean)
-        self.surfH = cuda.to_device(surfH)
+        # Resident state (read/write; refreshed in upload, read back in download).
+        self.subT = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self.subD = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self.subZ = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self.subW = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self.subS = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self.subTmean = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self.surfH = cuda.device_array((gpsum,), dtype=np.float64)
 
         # Per-step inputs (read-only on the device).
-        self.logyearsnow = cuda.to_device(logyearsnow)
-        self.yearsnow = cuda.to_device(yearsnow)
-        self.WS = cuda.to_device(WS)
-        self.Tsurf = cuda.to_device(Tsurf)
-        self.sumWinit = cuda.to_device(sumWinit)
+        self.logyearsnow = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self.yearsnow = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self.WS = cuda.device_array((gpsum,), dtype=np.float64)
+        self.Tsurf = cuda.device_array((gpsum,), dtype=np.float64)
+        self.sumWinit = cuda.device_array((gpsum,), dtype=np.float64)
+
+        # Dens_* diagnostics, refreshed from the host zeros each step.
+        self.Dens_destr_metam = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self.Dens_overb_pres = cuda.device_array((gpsum, nl), dtype=np.float64)
+        self.Dens_drift = cuda.device_array((gpsum, nl), dtype=np.float64)
 
         # Conductivity / heat capacity filled by the heat-conduction prep kernel
         # and kept resident so download() returns subK/subCeff matching NumPy.
@@ -623,12 +623,6 @@ class SnowDeviceState:
         self.refr_I = cuda.device_array((gpsum,), dtype=np.float64)
         self.slushw = cuda.device_array((gpsum,), dtype=np.float64)
         self.irrw = cuda.device_array((gpsum,), dtype=np.float64)
-
-        # Dens_* diagnostics: uploaded in compaction() as host zeros so that
-        # firn_only mode (where the kernel does not touch them) stays zero.
-        self.Dens_destr_metam = None
-        self.Dens_overb_pres = None
-        self.Dens_drift = None
 
         # Device-only scratch (never touches the host).
         self._subD_old = cuda.device_array((gpsum, nl), dtype=np.float64)
@@ -650,6 +644,35 @@ class SnowDeviceState:
         self._carrot_ws = cuda.device_array((gpsum, nl), dtype=np.float64)
         self._slushspace_ws = cuda.device_array((gpsum, nl), dtype=np.float64)
 
+    def upload(
+        self,
+        subT,
+        subD,
+        subZ,
+        subW,
+        subS,
+        subTmean,
+        surfH,
+        logyearsnow,
+        yearsnow,
+        WS,
+        Tsurf,
+        sumWinit,
+    ):
+        """Refresh the device buffers with this timestep's host state."""
+        self.subT.copy_to_device(subT)
+        self.subD.copy_to_device(subD)
+        self.subZ.copy_to_device(subZ)
+        self.subW.copy_to_device(subW)
+        self.subS.copy_to_device(subS)
+        self.subTmean.copy_to_device(subTmean)
+        self.surfH.copy_to_device(surfH)
+        self.logyearsnow.copy_to_device(logyearsnow)
+        self.yearsnow.copy_to_device(yearsnow)
+        self.WS.copy_to_device(WS)
+        self.Tsurf.copy_to_device(Tsurf)
+        self.sumWinit.copy_to_device(sumWinit)
+
     def compaction(
         self,
         Dens_destr_metam,
@@ -664,9 +687,9 @@ class SnowDeviceState:
     ):
         """Launch the compaction kernel on the resident arrays."""
         # Upload host-zeroed diagnostics; firn_only leaves them untouched.
-        self.Dens_destr_metam = cuda.to_device(Dens_destr_metam)
-        self.Dens_overb_pres = cuda.to_device(Dens_overb_pres)
-        self.Dens_drift = cuda.to_device(Dens_drift)
+        self.Dens_destr_metam.copy_to_device(Dens_destr_metam)
+        self.Dens_overb_pres.copy_to_device(Dens_overb_pres)
+        self.Dens_drift.copy_to_device(Dens_drift)
 
         # Snapshot pre-compaction subD/subZ on-device (host path does .copy()).
         self._subD_old.copy_to_device(self.subD)
@@ -814,6 +837,60 @@ class SnowDeviceState:
         self.kk.copy_to_host(OUT["subK"])
         self.c_eff.copy_to_host(OUT["subCeff"])
         OUT["cpi"] = 152.2 + 7.122 * OUT["subT"]
+
+
+# ---------------------------------------------------------------------------
+# Cached device state
+#
+# The device buffers depend only on the grid shape, so one SnowDeviceState is
+# allocated per run and reused for every timestep. Re-creating it each step
+# would re-allocate ~25 device arrays, and cudaMalloc/cudaFree serialise
+# against the compute stream.
+#
+# Module-level state mirrors how compute_backend.py keeps the active backend.
+# ---------------------------------------------------------------------------
+
+_device_state = None
+
+
+def get_device_state(
+    subT,
+    subD,
+    subZ,
+    subW,
+    subS,
+    subTmean,
+    surfH,
+    logyearsnow,
+    yearsnow,
+    WS,
+    Tsurf,
+    sumWinit,
+):
+    """Return the cached SnowDeviceState, refreshed with the current host state.
+
+    Allocates on the first call (or if the grid shape changed) and uploads this
+    timestep's arrays into the existing device buffers on every call.
+    """
+    global _device_state
+    if _device_state is None or _device_state.shape != subD.shape:
+        gpsum, nl = subD.shape
+        _device_state = SnowDeviceState(gpsum, nl)
+    _device_state.upload(
+        subT,
+        subD,
+        subZ,
+        subW,
+        subS,
+        subTmean,
+        surfH,
+        logyearsnow,
+        yearsnow,
+        WS,
+        Tsurf,
+        sumWinit,
+    )
+    return _device_state
 
 
 # ===========================================================================

--- a/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
+++ b/src/ebfm/core/LOOP_SNOW_gpu_kernels.py
@@ -1453,7 +1453,12 @@ class SnowDeviceState:
                 OUT[key] = host
             self._download_2d(src, host)
 
-        self.sumWinit.copy_to_host(OUT["sumWinit"])
+        # Assign, do not copy into an existing array: on the GPU path nothing
+        # creates OUT["sumWinit"] beforehand. INIT does not allocate it and the
+        # NumPy melt_sublimation that would have is exactly what the device
+        # kernel replaced, so copy_to_host(OUT["sumWinit"]) raised KeyError on
+        # the first sync of every real run.
+        OUT["sumWinit"] = self.sumWinit.copy_to_host()
         OUT["Dfreshsnow"] = self.Dfreshsnow.copy_to_host()
         OUT["Dfreshsnow_T"] = self.Dfreshsnow_T.copy_to_host()
         OUT["Dfreshsnow_W"] = self.Dfreshsnow_W.copy_to_host()

--- a/src/ebfm/core/LOOP_mass_balance.py
+++ b/src/ebfm/core/LOOP_mass_balance.py
@@ -39,6 +39,12 @@ def main(OUT, IN, C):
 
     # Snow mass
     OUT["snowmass"] = np.maximum(OUT["snowmass"] + OUT["smb"], 0)
-    OUT["snowmass"][np.all(OUT["subD"] >= C["Dice"], axis=1)] = 0
+    # On the GPU backend subD stays resident on the device across timesteps, so
+    # LOOP_SNOW hands the column-wise reduction over ready-made rather than
+    # having the host pull the whole density grid back for it.
+    all_ice = OUT.get("all_ice_column")
+    if all_ice is None:
+        all_ice = np.all(OUT["subD"] >= C["Dice"], axis=1)
+    OUT["snowmass"][all_ice] = 0
 
     return OUT

--- a/src/ebfm/core/LOOP_write_to_file.py
+++ b/src/ebfm/core/LOOP_write_to_file.py
@@ -9,6 +9,16 @@ from netCDF4 import Dataset, date2num
 from .LOOP_general_functions import is_first_time_step, is_final_time_step
 
 
+def is_sample_step(io, t) -> bool:
+    """Return True on the timesteps where "sample"-type variables are recorded.
+
+    Exposed so callers can prepare state that is only needed then -- on the GPU
+    backend main() uses it to decide when the device-resident subsurface grids
+    have to be copied back (LOOP_SNOW.sync_gpu_state).
+    """
+    return (t + 1 + io["freqout"] // 2) % io["freqout"] == 0
+
+
 def main(OUTFILE, io, OUT, grid, t, time):
     # Specify variables to be written
     if is_first_time_step(t):
@@ -56,21 +66,23 @@ def main(OUTFILE, io, OUT, grid, t, time):
         varname, var_type = entry[0], entry[2]
         # "shade" is written as a fraction but sourced from the boolean OUT["is_shaded"]
         source_key = "is_shaded" if varname == "shade" else varname
-        temp_long = np.float64(OUT[source_key])
 
-        # Initialize TEMP storage
+        # Initialize TEMP storage (shape only, so no value is read here)
         if t % io["freqout"] == 0:
             OUTFILE.setdefault("TEMP", {})
-            OUTFILE["TEMP"][varname] = np.zeros_like(temp_long)
+            OUTFILE["TEMP"][varname] = np.zeros(np.shape(OUT[source_key]), dtype=np.float64)
 
-        # Handle type: sample, mean, or sum
+        # Handle type: sample, mean, or sum.
+        # "sample" variables -- which include the full subsurface grids -- are
+        # read only on the step they are recorded on, instead of being copied
+        # every timestep and thrown away.
         if var_type == "sample":
-            if (t + 1 + io["freqout"] // 2) % io["freqout"] == 0:  # TODO: correct?
-                OUTFILE["TEMP"][varname] = temp_long
+            if is_sample_step(io, t):  # TODO: correct?
+                OUTFILE["TEMP"][varname] = np.float64(OUT[source_key])
         elif var_type == "mean":
-            OUTFILE["TEMP"][varname] += temp_long / io["freqout"]
+            OUTFILE["TEMP"][varname] += np.float64(OUT[source_key]) / io["freqout"]
         elif var_type == "sum":
-            OUTFILE["TEMP"][varname] += temp_long
+            OUTFILE["TEMP"][varname] += np.float64(OUT[source_key])
 
     def save_binary_files():
         """

--- a/src/ebfm/main.py
+++ b/src/ebfm/main.py
@@ -271,6 +271,11 @@ def _main_impl():
         # TODO: should be supported for all cases to avoid case distinction here
         if not grid["is_partitioned"] and isinstance(coupler, ebfm.coupling.DummyCoupler):
             if grid_config.grid_type is GridInputType.MATLAB:
+                # The subsurface grids are written as "sample" variables, so on
+                # the GPU backend they only have to leave the device on the
+                # steps that actually record one.
+                if LOOP_write_to_file.is_sample_step(io, t):
+                    LOOP_SNOW.sync_gpu_state(OUT)
                 io, OUTFILE = LOOP_write_to_file.main(OUTFILE, io, OUT, grid, t, time)
             else:
                 logger.warning("Skipping writing output to file for Elmer input grids.")
@@ -283,7 +288,7 @@ def _main_impl():
     # Write restart file
     # TODO: should be supported for all cases to avoid case distinction here
     if not grid["is_partitioned"]:
-        LOOP_SNOW.flush_gpu_diagnostics(OUT)
+        LOOP_SNOW.sync_gpu_state(OUT)
         FINAL_create_restart_file.main(OUT, io, args.restart_dir)
     else:
         logger.warning("Skipping writing of restart file for coupled and/or partitioned runs.")
@@ -291,7 +296,7 @@ def _main_impl():
     logger.info("Time loop completed.")
 
     if args.dump_reference:
-        LOOP_SNOW.flush_gpu_diagnostics(OUT)
+        LOOP_SNOW.sync_gpu_state(OUT)
         dump_reference(logger, OUT, args.dump_reference)
 
     coupler.finalize()

--- a/src/ebfm/main.py
+++ b/src/ebfm/main.py
@@ -283,6 +283,7 @@ def _main_impl():
     # Write restart file
     # TODO: should be supported for all cases to avoid case distinction here
     if not grid["is_partitioned"]:
+        LOOP_SNOW.flush_gpu_diagnostics(OUT)
         FINAL_create_restart_file.main(OUT, io, args.restart_dir)
     else:
         logger.warning("Skipping writing of restart file for coupled and/or partitioned runs.")
@@ -290,6 +291,7 @@ def _main_impl():
     logger.info("Time loop completed.")
 
     if args.dump_reference:
+        LOOP_SNOW.flush_gpu_diagnostics(OUT)
         dump_reference(logger, OUT, args.dump_reference)
 
     coupler.finalize()

--- a/tests/core/test_loop_snow_gpu.py
+++ b/tests/core/test_loop_snow_gpu.py
@@ -105,8 +105,10 @@ def _make_case(gpsum=48, nl=50, seed=7, snow_compaction="firn+snow", percolation
     OUT["moist_evaporation"] = rng.uniform(0.0, 1e-4, gpsum)
     OUT["runoff_irr_deep_mean"] = rng.uniform(0.0, 1.0, gpsum)
     # Deliberately NOT seeded here: "sumWinit", "cpi", "Dens_*" and "runoff_irr"
-    # are not created by INIT either, LOOP_SNOW produces them. Seeding them
-    # would hide a backend that only ever writes into an existing host array.
+    # are not created by INIT either -- LOOP_SNOW produces them. Seeding them
+    # would hide a backend that only ever writes *into* an existing host array,
+    # which is how the GPU path once failed with KeyError on the first
+    # sync_gpu_state() of a real run.
 
     IN = {}
     IN["T"] = C["T0"] - rng.uniform(-5.0, 25.0, gpsum)

--- a/tests/core/test_loop_snow_gpu.py
+++ b/tests/core/test_loop_snow_gpu.py
@@ -93,10 +93,6 @@ def _make_case(gpsum=48, nl=50, seed=7, snow_compaction="firn+snow", percolation
     OUT["subS"][1::3, :] = 0.0
     OUT["surfH"] = rng.uniform(-1.0, 1.0, gpsum)
     OUT["Tsurf"] = C["T0"] - rng.uniform(0.0, 15.0, gpsum)
-    # Conductivity / heat capacity diagnostics: INIT allocates these, and the
-    # GPU path writes the kernel results back into them in place.
-    OUT["subK"] = np.zeros((gpsum, nl))
-    OUT["subCeff"] = np.zeros((gpsum, nl))
 
     # Surface energy balance results consumed by LOOP_SNOW.
     OUT["melt"] = rng.uniform(0.0, 0.02, gpsum)
@@ -174,9 +170,10 @@ class TestLoopSnowGPUMatchesNumPy(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        from ebfm.core import LOOP_SNOW, compute_backend
+        from ebfm.core import LOOP_SNOW, LOOP_SNOW_gpu_kernels, compute_backend
 
         cls.LOOP_SNOW = LOOP_SNOW
+        cls.gpu_kernels = LOOP_SNOW_gpu_kernels
         cls.compute_backend = compute_backend
 
         # The drift-densification time scale divides by a gamma that underflows
@@ -187,9 +184,13 @@ class TestLoopSnowGPUMatchesNumPy(unittest.TestCase):
         warnings.filterwarnings("ignore", message="divide by zero encountered", category=RuntimeWarning)
 
     def setUp(self):
+        # Each test starts from a clean device state, otherwise the resident
+        # buffers of a previous test would be reused.
+        self.gpu_kernels._device_state = None
         self.compute_backend._backend = self.compute_backend.ComputeBackend.NUMPY
 
     def tearDown(self):
+        self.gpu_kernels._device_state = None
         self.compute_backend._backend = self.compute_backend.ComputeBackend.NUMPY
 
     def _run(self, backend, steps, **case):
@@ -201,6 +202,7 @@ class TestLoopSnowGPUMatchesNumPy(unittest.TestCase):
             # same inputs even though LOOP_SNOW overwrites some of them.
             _, IN_step = _deepcopy_state(OUT, IN)
             self.LOOP_SNOW.main(C, OUT, IN_step, dt, grid, phys)
+            self.LOOP_SNOW.sync_gpu_state(OUT)
         return OUT
 
     def _assert_matches(self, ref, got, context):
@@ -247,6 +249,30 @@ class TestLoopSnowGPUMatchesNumPy(unittest.TestCase):
                     self.setUp()
                     got = self._run(self.compute_backend.ComputeBackend.GPU, steps=1, **case)
                     self._assert_matches(ref, got, f"{snow_compaction}/{percolation}, 1 step")
+
+    def test_boundary_download_keeps_host_layers_current(self):
+        """The layers host code reads between timesteps must be up to date.
+
+        download_boundary() refreshes only part of the host grids; this checks
+        that the part it does refresh matches a full sync, so LOOP_EBM,
+        LOOP_EBM_SWout and LOOP_mass_balance see current values without one.
+        """
+        C, OUT, IN, dt, grid, phys = _make_case()
+        self.compute_backend._backend = self.compute_backend.ComputeBackend.GPU
+        _, IN_step = _deepcopy_state(OUT, IN)
+        self.LOOP_SNOW.main(C, OUT, IN_step, dt, grid, phys)
+
+        partial = {k: (v.copy() if isinstance(v, np.ndarray) else v) for k, v in OUT.items()}
+        self.LOOP_SNOW.sync_gpu_state(OUT)
+
+        np.testing.assert_array_equal(partial["subD"][:, :2], OUT["subD"][:, :2])
+        np.testing.assert_array_equal(partial["subZ"][:, :2], OUT["subZ"][:, :2])
+        np.testing.assert_array_equal(partial["subT"][:, 1], OUT["subT"][:, 1])
+        np.testing.assert_array_equal(partial["T_ice"], OUT["subT"][:, -1])
+        np.testing.assert_array_equal(
+            partial["all_ice_column"],
+            np.all(OUT["subD"] >= C["Dice"], axis=1),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #157, which added the GPU backend. There the subsurface state moved between host and device twice per timestep. This MR makes the device the place the state actually lives.

What changed:

- Device buffers are allocated once per run instead of every timestep.
- Subsurface arrays are stored layer-major, so neighbouring threads read neighbouring addresses (coalesced access).
- All of `LOOP_SNOW` runs on the device: `snowfall_and_deposition`,  `melt_sublimation` and `layer_merging_and_splitting` have kernels too, so the state stays resident across timesteps and only the `(gpsum,)` forcing and result vectors move per step.
- Diagnostics stay on the device until something reads them; `sync_gpu_state()` copies the full grids back for the netCDF sample, the restart file and `--dump-reference`.
- `LOOP_EBM` and `LOOP_write_to_file` read only the layers and timesteps they actually need. Bit-identical for every backend.

Correctness:

 `tests/core/test_loop_snow_gpu.py` covers the resident-state path on numba's CUDA simulator (no GPU needed) and the NumPy path is bit-identical to main on the MATLAB example with `--random-seed 42`.

A more detailed view of all optimizations is collected here:
https://github.com/HOR-INFRAEU-TerraDT/performance_land-ice-dtc
(WIP - not added yet)


# Author's Todos

- [ ] I ran the [pre-commit hooks](https://github.com/EBFMorg/EBFM?tab=readme-ov-file#developer-notes) and fixed all issues
- [ ] I added an entry under *develop* in the [CHANGELOG.md](https://github.com/EBFMorg/EBFM/blob/main/CHANGELOG.md) (may be skipped for minor changes not observable for the user)
